### PR TITLE
Added build metadata string formatting.

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -50,6 +50,7 @@ words:
   - rstrip
   - rwxr
   - seealso
+  - srcset
   - stringifying
   - termcolor
   - toctree

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from concoursetools import BuildMetadata
 from concoursetools.metadata import _flatten_dict
+from concoursetools.mocking import TestBuildMetadata
 from concoursetools.testing import create_env_vars, mock_environ
 
 
@@ -150,3 +151,30 @@ class MetadataTests(TestCase):
             "version.parents.to": "2.0.0",
         }
         self.assertDictEqual(_flatten_dict(nested_dict), flattened_dict)
+
+
+class MetadataFormattingTests(TestCase):
+    """
+    Tests for the BuildMetadata.format_string method.
+    """
+    def setUp(self) -> None:
+        """Code to run before each test."""
+        self.metadata = TestBuildMetadata()
+
+    def test_no_interpolation(self) -> None:
+        new_string = self.metadata.format_string("This is a normal string.")
+        self.assertEqual(new_string, "This is a normal string.")
+
+    def test_simple_interpolation(self) -> None:
+        new_string = self.metadata.format_string("The build id is $BUILD_ID and the job name is $BUILD_JOB_NAME.")
+        self.assertEqual(new_string, "The build id is 12345678 and the job name is my-job.")
+
+    def test_interpolation_with_one_off(self) -> None:
+        metadata = TestBuildMetadata(one_off_build=True)
+        new_string = metadata.format_string("The build id is $BUILD_ID and the job name is $BUILD_JOB_NAME.")
+        self.assertEqual(new_string, "The build id is 12345678 and the job name is .")
+
+    def test_interpolation_incorrect_value(self) -> None:
+        metadata = TestBuildMetadata(one_off_build=True)
+        new_string = metadata.format_string("The build id is $OTHER.")
+        self.assertEqual(new_string, "The build id is $OTHER.")


### PR DESCRIPTION
Fixes #4.

This new feature allows users to format a string with build metadata, which is useful for allowing pipeline users to use these values when invoking the resource, such as in commit messages.

The decision to use `$BUILD_ID`-style of formatting instead of f-strings or similar was for familiarity across users, but also because a number of other resource types have used a similar formatting before.

Also added a word to the `cspell` config, and fixed a failing doctest.