### PR TITLE
Better `BuildMetadata.format_string` implementation.

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -59,6 +59,7 @@ words:
   - unitless
   - urllib
   - vars
+  - versionadded
   - viewcode
   - WORKDIR
   - xkcd

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -34,6 +34,7 @@ words:
   - INPROGRESS
   - intersphinx
   - kwargs
+  - linecount
   - linenos
   - linkcheck
   - Liskov

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
     "extensions.concourse",
+    "extensions.linecount",
     "extensions.wikipedia",
     "extensions.xkcd",
 ]

--- a/docs/source/examples/branches.rst
+++ b/docs/source/examples/branches.rst
@@ -84,7 +84,7 @@ When the branches change (either with new ones added or existing ones removed) a
 GitHub Branches Conclusion
 --------------------------
 
-The final module only requires **43 lines** (including docstrings) and looks like this:
+The final module only requires :linecount:`../../../examples/github_branches.py` lines (including docstrings) and looks like this:
 
 .. literalinclude:: ../../../examples/github_branches.py
     :linenos:

--- a/docs/source/examples/build_status.rst
+++ b/docs/source/examples/build_status.rst
@@ -179,7 +179,7 @@ Finally we submit the request and return the new version:
 
 Conclusion
 ----------
-The original repository scripts cover 12 Python files and a total of 433 lines. With Concourse tools, this same code is covered in 185 lines, and a single Python file:
+The original repository scripts cover 12 Python files and a total of 433 lines. With Concourse tools, this same code is covered in :linecount:`../../../examples/build_status.py` lines, and a single Python file:
 
 .. literalinclude:: ../../../examples/build_status.py
     :linenos:

--- a/docs/source/examples/build_status.rst
+++ b/docs/source/examples/build_status.rst
@@ -154,6 +154,18 @@ Next, we determine the URL to which to :func:`~requests.post` our request:
     :end-at: /statuses/build
     :dedent:
 
+.. tip::
+    .. versionadded:: 0.8.0
+
+        The :meth:`~concoursetools.metadata.BuildMetadata.format_string` method can be used to substitute build metadata
+        into the status description in order to allow users to reference the build:
+
+        .. literalinclude:: ../../../examples/build_status.py
+            :pyobject: Resource.publish_new_version
+            :start-at: build_metadata.format_string
+            :end-at: build_metadata.format_string
+            :dedent:
+
 Finally we submit the request and return the new version:
 
 .. literalinclude:: ../../../examples/build_status.py
@@ -167,7 +179,7 @@ Finally we submit the request and return the new version:
 
 Conclusion
 ----------
-The original repository scripts cover 12 Python files and a total of 433 lines. With Concourse tools, this same code is covered in 172 lines, and a single Python file:
+The original repository scripts cover 12 Python files and a total of 433 lines. With Concourse tools, this same code is covered in 185 lines, and a single Python file:
 
 .. literalinclude:: ../../../examples/build_status.py
     :linenos:

--- a/docs/source/examples/pipeline.rst
+++ b/docs/source/examples/pipeline.rst
@@ -118,7 +118,7 @@ We start with the execution description. We include an optional parameter to all
 Pipeline Conclusion
 -------------------
 
-The final resource only requires **135 lines of code**, and looks like this:
+The final resource only requires :linecount:`../../../examples/pipeline.py` lines of code, and looks like this:
 
 .. literalinclude:: ../../../examples/pipeline.py
     :linenos:

--- a/docs/source/examples/s3.rst
+++ b/docs/source/examples/s3.rst
@@ -70,7 +70,7 @@ Once the implicit :concourse:`get-step` is completed, the URL can then be :conco
 URL Conclusion
 --------------
 
-The final resource only requires **49 lines of code**, and looks like this:
+The final resource only requires :linecount:`../../../examples/s3.py` lines of code, and looks like this:
 
 .. literalinclude:: ../../../examples/s3.py
     :linenos:

--- a/docs/source/examples/secrets.rst
+++ b/docs/source/examples/secrets.rst
@@ -71,7 +71,7 @@ The behaviour is as follows:
 AWS Secrets Conclusion
 ----------------------
 
-We have added a lot of functionality for this resource in only **104 lines of code**. The final module looks like this:
+We have added a lot of functionality for this resource in only :linecount:`../../../examples/secrets.py` lines of code. The final module looks like this:
 
 .. literalinclude:: ../../../examples/secrets.py
     :linenos:

--- a/docs/source/examples/xkcd.rst
+++ b/docs/source/examples/xkcd.rst
@@ -87,7 +87,7 @@ We don't intend for the resource to publish new comics (unless :wikipedia:`Randa
 xkcd Conclusion
 ---------------
 
-The final resource only requires **93 lines of code**, and looks like this:
+The final resource only requires :linecount:`../../../examples/xkcd.py` lines of code, and looks like this:
 
 .. literalinclude:: ../../../examples/xkcd.py
     :linenos:

--- a/docs/source/extensions/linecount.py
+++ b/docs/source/extensions/linecount.py
@@ -1,0 +1,60 @@
+# (C) Crown Copyright GCHQ
+"""
+Minor Sphinx extension for counting the number of lines in a file.
+
+:linecount:`../relative/path/to/file.txt` will be replaced with the number of lines in `file.txt`.
+
+Paths should be relative to the directory of the current file, not the source directory.
+This is the same  path passed to literalinclude.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from docutils import nodes
+from docutils.nodes import system_message
+from docutils.parsers.rst.states import Inliner
+from sphinx.application import Sphinx
+
+__all__ = ("count_lines", "setup")
+
+
+def count_lines(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, Any] = {},
+                content: list[str] = []) -> tuple[list[nodes.reference], list[system_message]]:
+    """
+    Add a text node containing the number of lines.
+
+    :param name: The local name of the interpreted role, the role name actually used in the document.
+    :param rawtext: A string containing the entire interpreted text input, including the role and markup.
+    :param text: The interpreted text content.
+    :param lineno: The line number where the interpreted text begins.
+    :param inliner: The :class:`docutils.parsers.rst.states.Inliner` object that called :func:`~.source_role`.
+                    It contains the several attributes useful for error reporting and document tree access.
+    :param options: A dictionary of directive options for customization (from the ``role`` directive),
+                    to be interpreted by the function. Used for additional attributes for the generated elements
+                    and other functionality.
+    :param content: A list of strings, the directive content for customization (from the ``role`` directive).
+                    To be interpreted by the function.
+
+    :return: A list containing the created node, and a list containing any messages generated during the function.
+    """
+    path = Path(nodes.unescape(text))
+    page_path = Path(Path(inliner.document.settings._source))  # type: ignore
+    resolved_path = (page_path.parent / path).resolve()
+    with open(resolved_path) as rf:
+        line_count = sum(1 for _ in rf)
+
+    node = nodes.Text(str(line_count))
+    return [node], []
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """
+    Attach the extension to the application.
+
+    :param app: The Sphinx application.
+    """
+    app.add_role("linecount", count_lines)
+
+    return {"parallel_read_safe": True}

--- a/examples/build_status.py
+++ b/examples/build_status.py
@@ -136,6 +136,8 @@ class Resource(OutOnlyConcourseResource):
             else:
                 name = f"{build_metadata.BUILD_JOB_NAME} #{build_metadata.BUILD_NAME}"
 
+        description = build_metadata.format_string(description)
+
         if self.driver is Driver.SERVER:
             post_url = f"{self.endpoint}/rest/build-status/1.0/commits/{commit_hash}"
             if self.verify_ssl is False:

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ botocore==1.31.25
 certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==3.2.0
-cryptography==41.0.4
+cryptography==41.0.7
 idna==3.4
 Jinja2==3.1.2
 jmespath==1.0.1

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,7 @@ try:
     from moto.sagemaker.models import FakePipelineExecution
     from moto.sagemaker.responses import TYPE_RESPONSE, SageMakerResponse
 except ImportError:
-    raise unittest.SkipTest("Cannot proceed without example dependencies - see 'requirements.txt'")
+    raise unittest.SkipTest("Cannot proceed without example dependencies - see 'requirements-tests.txt'")
 
 from concoursetools.mocking import TestBuildMetadata
 from concoursetools.testing import SimpleTestResourceWrapper

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -175,6 +175,14 @@ class MetadataFormattingTests(TestCase):
         self.assertEqual(new_string, "The build id is 12345678 and the job name is .")
 
     def test_interpolation_incorrect_value(self) -> None:
-        metadata = TestBuildMetadata(one_off_build=True)
-        new_string = metadata.format_string("The build id is $OTHER.")
+        with self.assertRaises(KeyError):
+            self.metadata.format_string("The build id is $OTHER.")
+
+    def test_interpolation_incorrect_value_ignore_missing(self) -> None:
+        new_string = self.metadata.format_string("The build id is $OTHER.", ignore_missing=True)
         self.assertEqual(new_string, "The build id is $OTHER.")
+
+    def test_interpolation_with_additional(self) -> None:
+        new_string = self.metadata.format_string("The build id is $OTHER.", additional_values={"OTHER": "value"},
+                                                 ignore_missing=True)
+        self.assertEqual(new_string, "The build id is value.")


### PR DESCRIPTION
The following small changes:

* The `BuildMetadata.format_string` now uses `string.Template` to interpolate.
* Added a mention in the examples section of this new method
* Added a new Sphinx extension (`linecount.py`) to properly count the number of lines in the examples, instead of needing to manually update them.
* Bumped the cryptography path version in the test requirements.