### PR TITLE
Modern Typing

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,6 +45,11 @@ repos:
     hooks:
     - id: pyroma
       args: ["-d", "--min=10", ".", "--skip-tests", "ValidREST"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.1
+    hooks:
+      - id: mypy
+        additional_dependencies: ["types-docutils", "types-python-dateutil", "types-requests"]
   - repo: https://github.com/johannsdg/pre-commit-license-headers
     rev: d53087d331942f263cb553dc67b0e51ffa3a3481
     hooks:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![version](https://img.shields.io/badge/version-0.7.1-informational)
 ![pre-release](https://img.shields.io/badge/pre--release-beta-red)
-![python](https://img.shields.io/badge/python-%3E%3D3.8-informational)
+![python](https://img.shields.io/badge/python-%3E%3D3.9-informational)
 ![coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)
 ![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=orange)
 

--- a/concoursetools/__main__.py
+++ b/concoursetools/__main__.py
@@ -15,26 +15,27 @@ To see additional options, run:
 
     python3 -m concoursetools -h
 """
+from __future__ import annotations
+
 import argparse
-import pathlib
+from pathlib import Path
 import sys
-from typing import List
 
 from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile, import_resource_class_from_module
 
 
-def main(args: List[str] = sys.argv[1:]) -> None:  # pylint: disable=dangerous-default-value
+def main(args: list[str] = sys.argv[1:]) -> None:  # pylint: disable=dangerous-default-value
     """Run the main function."""
     parsed_args = parse_args(args)
     if parsed_args.docker:
         create_dockerfile(parsed_args)
         return
 
-    resource_class = import_resource_class_from_module(parsed_args.resource_path, parsed_args.class_name)
-    create_asset_scripts(pathlib.Path(parsed_args.path), resource_class, parsed_args.executable)
+    resource_class = import_resource_class_from_module(parsed_args.resource_path, parsed_args.class_name)  # type: ignore[var-annotated]
+    create_asset_scripts(Path(parsed_args.path), resource_class, parsed_args.executable)
 
 
-def parse_args(args: List[str]) -> Namespace:
+def parse_args(args: list[str]) -> Namespace:
     """Parse command line args."""
     parser = argparse.ArgumentParser()
     parser.add_argument("path", type=str, help="The location at which to place the scripts")

--- a/concoursetools/colour.py
+++ b/concoursetools/colour.py
@@ -11,8 +11,11 @@ and so a handful of rudimentary functions for formatting with colour are include
     Concourse Tools specifically has no external dependencies, and so these
     must be actively installed and managed by a user.
 """
+from __future__ import annotations
+
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any
 
 END_COLOUR = "\033[0m"
 BOLD = "\033[1m"
@@ -49,7 +52,7 @@ def colourise(string: str, colour: str) -> str:
     return f"{colour}{string}{END_COLOUR}"
 
 
-def colour_print(*values: Any, colour: str = MISSING_COLOUR, bold: bool = False, underline: bool = False,
+def colour_print(*values: object, colour: str = MISSING_COLOUR, bold: bool = False, underline: bool = False,
                  **print_kwargs: Any) -> None:
     """
     Print something in colour.

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -2,35 +2,38 @@
 """
 Functions for creating the Dockerfile or asset files.
 """
+from __future__ import annotations
+
+from collections.abc import Callable
 from dataclasses import dataclass
 import importlib
 import inspect
-import pathlib
+from pathlib import Path
 import sys
 import textwrap
 from types import MethodType
-from typing import Any, Callable, Dict, Optional, Type, cast
+from typing import cast
 
 from concoursetools import ConcourseResource
-from concoursetools.typing import VersionProtocol
+from concoursetools.typing import VersionProtocol, VersionT
 
 DEFAULT_EXECUTABLE = "/usr/bin/env python3"
 DEFAULT_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
-def create_dockerfile(args: "Namespace", encoding: Optional[str] = None,
-                      concoursetools_path: Optional[pathlib.Path] = None) -> None:
+def create_dockerfile(args: "Namespace", encoding: str | None = None,
+                      concoursetools_path: Path | None = None) -> None:
     """
     Create a skeleton dockerfile.
 
     :param args: The CLI args.
-    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
+    :param encoding: The encoding of the file as passed to :meth:`~Path.write_text`.
                      Setting to :obj:`None` (default) will use the user's default encoding.
     :param concoursetools_path: A path to a local copy of concoursetools. If not set to :obj:`None`, this directory
                                 will be copied over an installed before any requirements. Path should be relative to
                                 the current directory.
     """
-    directory_path = pathlib.Path(args.path)
+    directory_path = Path(args.path)
     if directory_path.is_dir():
         file_path = directory_path / "Dockerfile"
     else:
@@ -105,7 +108,7 @@ def create_dockerfile(args: "Namespace", encoding: Optional[str] = None,
     file_path.write_text(contents, encoding=encoding)
 
 
-def create_asset_scripts(assets_folder: pathlib.Path, resource_class: Type[ConcourseResource],  # type: ignore[type-arg]
+def create_asset_scripts(assets_folder: Path, resource_class: type[ConcourseResource],  # type: ignore[type-arg]
                          executable: str = DEFAULT_EXECUTABLE) -> None:
     """
     Create the scripts in a given folder.
@@ -118,7 +121,7 @@ def create_asset_scripts(assets_folder: pathlib.Path, resource_class: Type[Conco
     """
     assets_folder.mkdir(parents=True, exist_ok=True)
 
-    file_to_method: Dict[str, Callable[[], None]] = {
+    file_to_method: dict[str, Callable[[], None]] = {
         "check": resource_class.check_main,
         "in": resource_class.in_main,
         "out": resource_class.out_main,
@@ -128,8 +131,8 @@ def create_asset_scripts(assets_folder: pathlib.Path, resource_class: Type[Conco
         create_script_file(file_path, method, executable)
 
 
-def create_script_file(path: pathlib.Path, method: Callable[[], None], executable: str = DEFAULT_EXECUTABLE,
-                       permissions: int = 0o755, encoding: Optional[str] = None) -> None:
+def create_script_file(path: Path, method: Callable[[], None], executable: str = DEFAULT_EXECUTABLE,
+                       permissions: int = 0o755, encoding: str | None = None) -> None:
     """
     Create a script file at a given path.
 
@@ -137,15 +140,15 @@ def create_script_file(path: pathlib.Path, method: Callable[[], None], executabl
     :param method: The method of the :class:`~concoursetools.resource.ConcourseResource` to be exported.
     :param executable: The executable to use for the script (at the top).
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
-    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
+    :param encoding: The encoding of the file as passed to :meth:`~Path.write_text`.
                      Setting to :obj:`None` (default) will use the user's default encoding.
     """
     docstring = inspect.getdoc(method) or ""
     docstring_header, *_ = docstring.split("\n")
 
     method = cast(MethodType, method)
-    resource_class = cast(Type[ConcourseResource[VersionProtocol]], method.__self__)  # type: ignore[attr-defined]
-    method_name = method.__name__  # type: ignore[attr-defined]
+    resource_class = cast(type[ConcourseResource[VersionProtocol]], method.__self__)
+    method_name = method.__name__
 
     contents = textwrap.dedent(f"""
     #!{executable}
@@ -163,7 +166,7 @@ def create_script_file(path: pathlib.Path, method: Callable[[], None], executabl
     path.chmod(permissions)
 
 
-def file_path_to_import_path(file_path: pathlib.Path) -> str:
+def file_path_to_import_path(file_path: Path) -> str:
     """
     Convert a file path to an import path.
 
@@ -171,9 +174,9 @@ def file_path_to_import_path(file_path: pathlib.Path) -> str:
     :raises ValueError: If the path doesn't end in a '.py' extension.
 
     :Example:
-        >>> file_path_to_import_path(pathlib.Path("module.py"))
+        >>> file_path_to_import_path(Path("module.py"))
         'module'
-        >>> file_path_to_import_path(pathlib.Path("path/to/module.py"))
+        >>> file_path_to_import_path(Path("path/to/module.py"))
         'path.to.module'
     """
     *path_components, file_name = file_path.parts
@@ -186,8 +189,8 @@ def file_path_to_import_path(file_path: pathlib.Path) -> str:
     return import_path
 
 
-def import_resource_class_from_module(file_path: pathlib.Path, class_name: Optional[str] = None,
-                                      parent_class: Type[Any] = ConcourseResource) -> Type[Any]:
+def import_resource_class_from_module(file_path: Path, class_name: str | None = None,
+                                      parent_class: type[ConcourseResource[VersionT]] = ConcourseResource) -> type[ConcourseResource[VersionT]]:
     """
     Import the resource class from the module.
 
@@ -216,8 +219,9 @@ def import_resource_class_from_module(file_path: pathlib.Path, class_name: Optio
     return resource_class
 
 
-def import_resource_classes_from_module(file_path: pathlib.Path,
-                                        parent_class: Type[Any] = ConcourseResource) -> Dict[str, Type[Any]]:
+def import_resource_classes_from_module(file_path: Path,
+                                        parent_class: type[ConcourseResource[VersionT]] = ConcourseResource
+                                        ) -> dict[str, type[ConcourseResource[VersionT]]]:
     """
     Import all available resource classes from the module.
 
@@ -255,11 +259,11 @@ class Namespace:
     path: str
     executable: str = DEFAULT_EXECUTABLE
     resource_file: str = "concourse.py"
-    class_name: Optional[str] = None
+    class_name: str | None = None
     docker: bool = False
     include_rsa: bool = False
 
     @property
-    def resource_path(self) -> pathlib.Path:
+    def resource_path(self) -> Path:
         """Return a path object pointing to the resource file."""
-        return pathlib.Path(self.resource_file)
+        return Path(self.resource_file)

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -239,8 +239,19 @@ def import_resource_classes_from_module(file_path: Path,
             raise FileNotFoundError(file_path) from error
         raise
 
-    possible_resource_classes = {cls.__name__: cls for _, cls in inspect.getmembers(module, predicate=inspect.isclass)
-                                 if issubclass(cls, parent_class) and cls.__module__ == import_path and not cls.__name__.startswith("_")}
+    possible_resource_classes: dict[str, type[ConcourseResource[VersionT]]] = {}
+    for _, cls in inspect.getmembers(module, predicate=inspect.isclass):
+        try:
+            class_is_subclass_of_parent = issubclass(cls, parent_class)
+        except TypeError:
+            class_is_subclass_of_parent = False
+
+        class_is_defined_in_this_module = (cls.__module__ == import_path)
+        class_is_not_private = (not cls.__name__.startswith("_"))
+
+        if class_is_subclass_of_parent and class_is_defined_in_this_module and class_is_not_private:
+            possible_resource_classes[cls.__name__] = cls
+
     return possible_resource_classes
 
 

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -27,7 +27,7 @@ def create_dockerfile(args: "Namespace", encoding: str | None = None,
     Create a skeleton dockerfile.
 
     :param args: The CLI args.
-    :param encoding: The encoding of the file as passed to :meth:`~Path.write_text`.
+    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
                      Setting to :obj:`None` (default) will use the user's default encoding.
     :param concoursetools_path: A path to a local copy of concoursetools. If not set to :obj:`None`, this directory
                                 will be copied over an installed before any requirements. Path should be relative to
@@ -140,7 +140,7 @@ def create_script_file(path: Path, method: Callable[[], None], executable: str =
     :param method: The method of the :class:`~concoursetools.resource.ConcourseResource` to be exported.
     :param executable: The executable to use for the script (at the top).
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
-    :param encoding: The encoding of the file as passed to :meth:`~Path.write_text`.
+    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
                      Setting to :obj:`None` (default) will use the user's default encoding.
     """
     docstring = inspect.getdoc(method) or ""

--- a/concoursetools/metadata.py
+++ b/concoursetools/metadata.py
@@ -12,10 +12,12 @@ The :meth:`~concoursetools.resource.ConcourseResource.download_version` and
 
 See the Concourse :concourse:`implementing-resource-types.resource-metadata` documentation for more information.
 """
+from __future__ import annotations
+
 import json
 import os
 from string import Template as StringTemplate
-from typing import Any, Dict, Optional
+from typing import Any
 from urllib.parse import quote
 
 
@@ -42,9 +44,9 @@ class BuildMetadata:  # pylint: disable=invalid-name
 
         These can still be accessed via :obj:`os.environ`, but they are not supported by Concourse Tools.
     """
-    def __init__(self, BUILD_ID: str, BUILD_TEAM_NAME: str, ATC_EXTERNAL_URL: str, BUILD_NAME: Optional[str] = None,
-                 BUILD_JOB_NAME: Optional[str] = None, BUILD_PIPELINE_NAME: Optional[str] = None,
-                 BUILD_PIPELINE_INSTANCE_VARS: Optional[str] = None):
+    def __init__(self, BUILD_ID: str, BUILD_TEAM_NAME: str, ATC_EXTERNAL_URL: str, BUILD_NAME: str | None = None,
+                 BUILD_JOB_NAME: str | None = None, BUILD_PIPELINE_NAME: str | None = None,
+                 BUILD_PIPELINE_INSTANCE_VARS: str | None = None):
         self.BUILD_ID = BUILD_ID
         self.BUILD_TEAM_NAME = BUILD_TEAM_NAME
 
@@ -97,7 +99,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
         """Return :obj:`True` if this is an :concourse:`instanced pipeline <instanced-pipelines>`."""
         return self.BUILD_PIPELINE_INSTANCE_VARS is not None
 
-    def instance_vars(self) -> Dict[str, Any]:
+    def instance_vars(self) -> dict[str, object]:
         """
         Return the instance vars set on this pipeline as a mapping.
 
@@ -137,7 +139,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
                     }
                 }
         """
-        instance_vars: Dict[str, Any] = json.loads(self.BUILD_PIPELINE_INSTANCE_VARS or "{}")
+        instance_vars: dict[str, object] = json.loads(self.BUILD_PIPELINE_INSTANCE_VARS or "{}")
         return instance_vars
 
     def build_url(self) -> str:
@@ -161,14 +163,14 @@ class BuildMetadata:  # pylint: disable=invalid-name
 
         return f"{self.ATC_EXTERNAL_URL}/{quote(build_path)}{query_string}"
 
-    def format_string(self, string: str, additional_values: Optional[Dict[str, str]] = None,
+    def format_string(self, string: str, additional_values: dict[str, str] | None = None,
                       ignore_missing: bool = False) -> str:
         """
         Format a string with metadata using standard bash ``$`` notation.
 
         Only a handful of "safe" values will be interpolated, not arbitrary attributes on the instance.
         These are the :concourse:`original environment variables <implementing-resource-types.resource-metadata>`,
-        including :attr:`BUILD_CREATED_BY` if it exists. Any missing environment variable (such as in the case of a
+        including :attr:`BUILD_CREATED_BY` if it exists. object missing environment variable (such as in the case of a
         one-off build) will be empty. A ``$BUILD_URL`` variable is also added for ease.
 
         .. danger::
@@ -192,7 +194,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
             'The build id is 12345678.'
         """
         template = StringTemplate(string)
-        possible_values: Dict[str, str] = {
+        possible_values: dict[str, str] = {
             "BUILD_ID": self.BUILD_ID,
             "BUILD_TEAM_NAME": self.BUILD_TEAM_NAME,
             "BUILD_NAME": self.BUILD_NAME or "",
@@ -226,7 +228,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
         )
 
 
-def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
+def _flatten_dict(d: dict[str, Any]) -> dict[str, Any]:
     """
     Flatten a nested dictionary into a single-level dictionary.
 
@@ -241,7 +243,7 @@ def _flatten_dict(d: Dict[str, Any]) -> Dict[str, Any]:
         >>> _flatten_dict(d)
         {'key_1': 'value_1', 'key_2.1': 'value_2_1', 'key_2.2': 'value_2_2'}
     """
-    flattened_dict: Dict[str, Any] = {}
+    flattened_dict: dict[str, object] = {}
     for key, value in d.items():
         if isinstance(value, dict):
             sub_flattened_dict = _flatten_dict(value)

--- a/concoursetools/mocking.py
+++ b/concoursetools/mocking.py
@@ -21,7 +21,6 @@ from concoursetools import BuildMetadata
 T = TypeVar("T")
 ContextManager = Generator[T, None, None]
 FolderDict = dict[str, Any]
-PathLike = Path | str
 
 
 def create_env_vars(one_off_build: bool = False, instance_vars: dict[str, str] | None = None, **env_vars: str) -> dict[str, str]:

--- a/concoursetools/resource.py
+++ b/concoursetools/resource.py
@@ -14,11 +14,13 @@ Find out more about resources in the :concourse:`Concourse resource documentatio
 To learn more about how Concourse resource types are actually implemented under the hood,
 check out :concourse:`implementing-resource-types` in Concourse.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 import contextlib
-import pathlib
+from pathlib import Path
 import sys
-from typing import Generic, List, Optional, Tuple, Type
+from typing import Generic
 
 from concoursetools import parsing
 from concoursetools.metadata import BuildMetadata
@@ -80,11 +82,11 @@ class ConcourseResource(ABC, Generic[VersionT]):
             The parameters need not be set as attributes if they can all be combined
             into a single class, such as an API wrapper or other construct.
     """
-    def __init__(self, version_class: Type[VersionT]):
+    def __init__(self, version_class: type[VersionT]):
         self.version_class = version_class
 
     @property
-    def certs_dir(self) -> pathlib.Path:
+    def certs_dir(self) -> Path:
         """
         The path to the Concourse worker's certificate directory.
 
@@ -94,10 +96,10 @@ class ConcourseResource(ABC, Generic[VersionT]):
 
         See the :concourse:`implementing-resource-types.resource-certs` documentation for more information.
         """
-        return pathlib.Path("/etc/ssl/certs")
+        return Path("/etc/ssl/certs")
 
     @abstractmethod
-    def fetch_new_versions(self, previous_version: Optional[VersionT] = None) -> List[VersionT]:
+    def fetch_new_versions(self, previous_version: VersionT | None = None) -> list[VersionT]:
         """
         Fetch new versions of the resource.
 
@@ -123,7 +125,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         """
 
     @abstractmethod
-    def download_version(self, version: VersionT, destination_dir: pathlib.Path, build_metadata: BuildMetadata) -> Tuple[VersionT, Metadata]:
+    def download_version(self, version: VersionT, destination_dir: Path, build_metadata: BuildMetadata) -> tuple[VersionT, Metadata]:
         """
         Download a version and place its files within the resource directory in your pipeline.
 
@@ -162,7 +164,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
 
         .. tip::
 
-            Any version returned by the :meth:`publish_new_version` method is passed to
+            object version returned by the :meth:`publish_new_version` method is passed to
             this method due to an implicit get step. The pipeline user has the option to
             set some additional parameters for this step, and so if you intend to upload
             something large in your put step, it might be worth including a flag in this
@@ -175,7 +177,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         """
 
     @abstractmethod
-    def publish_new_version(self, sources_dir: pathlib.Path, build_metadata: BuildMetadata) -> Tuple[VersionT, Metadata]:
+    def publish_new_version(self, sources_dir: Path, build_metadata: BuildMetadata) -> tuple[VersionT, Metadata]:
         """
         Update a resource by publishing a new version.
 
@@ -273,7 +275,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         _output(output)
 
     @classmethod
-    def _parse_check_input(cls) -> Tuple["ConcourseResource[VersionT]", Optional[VersionT]]:
+    def _parse_check_input(cls) -> tuple["ConcourseResource[VersionT]", VersionT | None]:
         """Parse input from the command line."""
         check_payload = sys.stdin.read()
 
@@ -289,12 +291,12 @@ class ConcourseResource(ABC, Generic[VersionT]):
         return resource, previous_version
 
     @classmethod
-    def _parse_in_input(cls) -> Tuple["ConcourseResource[VersionT]", VersionT, pathlib.Path, Params]:
+    def _parse_in_input(cls) -> tuple["ConcourseResource[VersionT]", VersionT, Path, Params]:
         """Parse input from the command line."""
         in_payload = sys.stdin.read()
 
         try:
-            destination_dir = pathlib.Path(sys.argv[1])
+            destination_dir = Path(sys.argv[1])
         except IndexError as error:
             raise ValueError("Path to the destination directory for the resource "
                              "must be passed to the command line") from error
@@ -307,12 +309,12 @@ class ConcourseResource(ABC, Generic[VersionT]):
         return resource, version, destination_dir, params
 
     @classmethod
-    def _parse_out_input(cls) -> Tuple["ConcourseResource[VersionT]", pathlib.Path, Params]:
+    def _parse_out_input(cls) -> tuple["ConcourseResource[VersionT]", Path, Params]:
         """Parse input from the command line."""
         out_payload = sys.stdin.read()
 
         try:
-            sources_dir = pathlib.Path(sys.argv[1])
+            sources_dir = Path(sys.argv[1])
         except IndexError as error:
             raise ValueError("Path to the directory containing the build's full set of sources "
                              "must be passed to the command line") from error

--- a/concoursetools/testing.py
+++ b/concoursetools/testing.py
@@ -554,7 +554,7 @@ class FileConversionTestResourceWrapper(FileTestResourceWrapper, Generic[Version
                        (See :func:`~concoursetools.dockertools.create_script_file`.)
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
                         (See :func:`~concoursetools.dockertools.create_script_file`.)
-    :param encoding: The encoding of the file as passed to :meth:`~Path.write_text`.
+    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
                      Setting to :obj:`None` (default) will use the user's default encoding.
                      (See :func:`~concoursetools.dockertools.create_script_file`.)
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`

--- a/concoursetools/testing.py
+++ b/concoursetools/testing.py
@@ -30,7 +30,6 @@ from concoursetools.typing import Metadata, MetadataPair, Params, ResourceConfig
 T = TypeVar("T")
 ContextManager = Generator[T, None, None]
 FolderDict = dict[str, Any]
-PathLike = Path | str
 
 
 class TestResourceWrapper(ABC, Generic[VersionT]):
@@ -844,7 +843,7 @@ class DockerConversionTestResourceWrapper(DockerTestResourceWrapper, Generic[Ver
 def run_docker_container(image: str, command: str, additional_args: list[str] | None = None,
                          env: dict[str, str] | None = None, cwd: Path | None = None,
                          stdin: str | None = None, rm: bool = True, interactive: bool = True,
-                         dir_mapping: dict[Path, PathLike] | None = None,
+                         dir_mapping: dict[Path, Path | str] | None = None,
                          hostname: str | None = None, local_only: bool = True) -> tuple[str, str]:
     """
     Run a command within the Docker container.

--- a/concoursetools/typing.py
+++ b/concoursetools/typing.py
@@ -7,37 +7,45 @@ Concourse Tools contains a small number of additional types for easier resource 
     class breaks the :wikipedia:`Liskov substitution principle`. If you wish to utilise type hinting
     in your development process, then please switch off the check for this type of method overloading.
 """
-from typing import Any, Callable, Dict, List, Literal, Protocol, Set, Type, TypeVar
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Protocol, TypedDict, TypeVar
 
 T = TypeVar("T")
 
 
-ResourceConfig = Dict[str, Any]
+ResourceConfig = dict[str, Any]
 """
 Represents arbitrary configuration passed to a Concourse resource.
 See the :concourse:`config-basics.schema.config` schema for more information.
 """
 
-Params = Dict[str, Any]
+Params = dict[str, Any]
 """
 Represents arbitrary parameters passed to a Concourse resource.
 See the :concourse:`config-basics.schema.config` schema for more information.
 """
 
-Metadata = Dict[str, str]
+Metadata = dict[str, str]
 """
 Represents :ref:`Step Metadata` as used by Concourse Tools.
 Restrictions on key and value types are determined by :data:`MetadataPair`.
 """
 
-MetadataPair = Dict[Literal["name", "value"], str]
-"""
-Represents :ref:`Step Metadata` as used internally by Concourse.
-Restrictions on key and value types are determined by the
-`Go structure itself <https://github.com/concourse/concourse/blob/master/atc/resource_types.go#L9>`_.
-"""
 
-VersionConfig = Dict[str, str]
+class MetadataPair(TypedDict):
+    """
+    Represents :ref:`Step Metadata` as used internally by Concourse.
+
+    Restrictions on key and value types are determined by the
+    `Go structure itself <https://github.com/concourse/concourse/blob/master/atc/resource_types.go#L9>`_.
+    """
+    name: str
+    value: str
+
+
+VersionConfig = dict[str, str]
 """
 Represents a version of a Concourse resource.
 See the :concourse:`config-basics.schema.version` schema for more information.
@@ -54,16 +62,13 @@ SortableVersionT = TypeVar("SortableVersionT", bound="SortableVersionProtocol")
 
 SortableVersionCovariantT = TypeVar("SortableVersionCovariantT", bound="SortableVersionProtocol", covariant=True)
 
-MultiVersionT = TypeVar("MultiVersionT", bound="MultiVersionProtocol")  # type: ignore[type-arg]
-"""Represents a generic :class:`~concoursetools.additional.MultiVersion` subclass."""
-
 
 class VersionProtocol(Protocol):
     """Corresponds to a generic :class:`~concoursetools.version.Version` subclass."""
     def __repr__(self) -> str:
         ...
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         ...
 
     def __hash__(self) -> int:
@@ -73,7 +78,7 @@ class VersionProtocol(Protocol):
         ...
 
     @classmethod
-    def from_flat_dict(cls: Type[VersionT], version_dict: VersionConfig) -> VersionT:
+    def from_flat_dict(cls: type[VersionT], version_dict: VersionConfig) -> VersionT:
         ...
 
 
@@ -82,7 +87,7 @@ class SortableVersionProtocol(Protocol):
     def __repr__(self) -> str:
         ...
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         ...
 
     def __hash__(self) -> int:
@@ -92,13 +97,13 @@ class SortableVersionProtocol(Protocol):
         ...
 
     @classmethod
-    def from_flat_dict(cls: Type[VersionT], version_dict: VersionConfig) -> VersionT:
+    def from_flat_dict(cls: type[VersionT], version_dict: VersionConfig) -> VersionT:
         ...
 
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         ...
 
-    def __le__(self, other: Any) -> bool:
+    def __le__(self, other: object) -> bool:
         ...
 
 
@@ -107,7 +112,7 @@ class TypedVersionProtocol(Protocol):
     def __repr__(self) -> str:
         ...
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         ...
 
     def __hash__(self) -> int:
@@ -117,7 +122,7 @@ class TypedVersionProtocol(Protocol):
         ...
 
     @classmethod
-    def from_flat_dict(cls: Type[VersionT], version_dict: VersionConfig) -> VersionT:
+    def from_flat_dict(cls: type[VersionT], version_dict: VersionConfig) -> VersionT:
         ...
 
     @classmethod
@@ -125,11 +130,11 @@ class TypedVersionProtocol(Protocol):
         ...
 
     @classmethod
-    def _un_flatten_object(cls, type_: Type[TypedVersionT], flat_obj: str) -> TypedVersionT:
+    def _un_flatten_object(cls, type_: type[TypedVersionT], flat_obj: str) -> TypedVersionT:
         ...
 
     @classmethod
-    def _get_attribute_type(cls, attribute_name: str) -> Type[Any]:
+    def _get_attribute_type(cls, attribute_name: str) -> type[Any]:
         ...
 
     @classmethod
@@ -137,27 +142,27 @@ class TypedVersionProtocol(Protocol):
         ...
 
     @classmethod
-    def un_flatten(cls, func: Callable[[Type[T], str], T]) -> Callable[[Type[T], str], T]:
+    def un_flatten(cls, func: Callable[[type[T], str], T]) -> Callable[[type[T], str], T]:
         ...
 
     @staticmethod
-    def _flatten_default(obj: Any) -> str:
+    def _flatten_default(obj: object) -> str:
         ...
 
     @staticmethod
-    def _un_flatten_default(type_: Type[T], flat_obj: str) -> T:
+    def _un_flatten_default(type_: type[T], flat_obj: str) -> T:
         ...
 
 
 class MultiVersionProtocol(Protocol[SortableVersionCovariantT]):
     """Corresponds to a generic :class:`~concoursetools.additional.MultiVersion` subclass."""
-    def __init__(self, versions: Set[SortableVersionCovariantT]):
+    def __init__(self, versions: set[SortableVersionCovariantT]):
         ...
 
     def __repr__(self) -> str:
         ...
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         ...
 
     def __hash__(self) -> int:
@@ -168,16 +173,16 @@ class MultiVersionProtocol(Protocol[SortableVersionCovariantT]):
         ...
 
     @property
-    def sub_version_class(self) -> Type[SortableVersionCovariantT]:
+    def sub_version_class(self) -> type[SortableVersionCovariantT]:
         ...
 
     @property
-    def sub_version_data(self) -> List[VersionConfig]:
+    def sub_version_data(self) -> list[VersionConfig]:
         ...
 
     def to_flat_dict(self) -> VersionConfig:
         ...
 
     @classmethod
-    def from_flat_dict(cls: Type[VersionT], version_dict: VersionConfig) -> VersionT:
+    def from_flat_dict(cls: type[VersionT], version_dict: VersionConfig) -> VersionT:
         ...

--- a/concoursetools/version.py
+++ b/concoursetools/version.py
@@ -149,7 +149,7 @@ class Version(ABC):
         .. tip::
 
             It is often useful to overload this method to deal with types such as :class:`set`,
-            :class:`~enum.Enum` and :class:`~Path`. However, it is also beneficial to
+            :class:`~enum.Enum` and :class:`~pathlib.Path`. However, it is also beneficial to
             instead inherit from :class:`~concoursetools.version.TypedVersion` instead.
         """
         return cls(**version_dict)

--- a/concoursetools/version.py
+++ b/concoursetools/version.py
@@ -5,12 +5,15 @@ defining what a version *actually is*, and this is defined with Concourse Tools 
 
 More information on versions can be found in the :concourse:`Concourse documentation <resource-versions>`.
 """
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections import UserDict
+from collections.abc import Callable, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, ClassVar, MutableMapping, Type, TypeVar, cast, get_type_hints
+from typing import Any, ClassVar, TypeVar, cast, get_type_hints
 
 from concoursetools.typing import TypedVersionT, VersionConfig, VersionT
 
@@ -56,7 +59,7 @@ class Version(ABC):
         attr_string = ", ".join(f"{attr}={value!r}" for attr, value in vars(self).items())
         return f"{type(self).__name__}({attr_string})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         return hash(self) == hash(other)
 
     def __hash__(self) -> int:
@@ -108,7 +111,7 @@ class Version(ABC):
         return {str(key): str(value) for key, value in vars(self).items() if not key.startswith("_")}
 
     @classmethod
-    def from_flat_dict(cls: Type[VersionT], version_dict: VersionConfig) -> VersionT:
+    def from_flat_dict(cls: type[VersionT], version_dict: VersionConfig) -> VersionT:
         """
         Load an instance from a dictionary representing the version.
 
@@ -146,7 +149,7 @@ class Version(ABC):
         .. tip::
 
             It is often useful to overload this method to deal with types such as :class:`set`,
-            :class:`~enum.Enum` and :class:`~pathlib.Path`. However, it is also beneficial to
+            :class:`~enum.Enum` and :class:`~Path`. However, it is also beneficial to
             instead inherit from :class:`~concoursetools.version.TypedVersion` instead.
         """
         return cls(**version_dict)
@@ -175,10 +178,10 @@ class SortableVersionMixin(ABC):
         ...             return NotImplemented
     """
     @abstractmethod
-    def __lt__(self, other: Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         pass
 
-    def __le__(self, other: Any) -> bool:
+    def __le__(self, other: object) -> bool:
         return bool(self < other or self == other)
 
 
@@ -210,7 +213,7 @@ class _TypeKeyDict(UserDict):  # type: ignore[type-arg]
         In almost all circumstances, this is the same type (in user-defined classes, for example),
         but avoids an issue in which a type from the typing module is set instead of the class it represents.
     """
-    def __getitem__(self, key: Type[Any]) -> Any:
+    def __getitem__(self, key: type[object]) -> object:
         for parent_class in key.mro():
             try:
                 return super().__getitem__(parent_class)
@@ -218,7 +221,7 @@ class _TypeKeyDict(UserDict):  # type: ignore[type-arg]
                 pass
         raise KeyError(f"{key} not found in mapping")
 
-    def __setitem__(self, key: Type[Any], item: Any) -> None:
+    def __setitem__(self, key: type[object], item: object) -> None:
         proper_key = key.mro()[0]  # almost always the same, except for objects in typing
         return super().__setitem__(proper_key, item)
 
@@ -254,8 +257,8 @@ class TypedVersion(Version):
         The full MRO of each object is looked up when calling the flatten and un-flatten functions, so any type which
         is a *subclass* of a registered type will still call the same functions, unless explicitly overwritten.
     """
-    _flatten_functions: ClassVar[MutableMapping[Type[Any], Callable[[Any], str]]] = _TypeKeyDict()
-    _un_flatten_functions: ClassVar[MutableMapping[Type[Any], Callable[[Type[Any], str], Any]]] = _TypeKeyDict()
+    _flatten_functions: ClassVar[MutableMapping[type[Any], Callable[[Any], str]]] = _TypeKeyDict()
+    _un_flatten_functions: ClassVar[MutableMapping[type[Any], Callable[[type[Any], str], Any]]] = _TypeKeyDict()
 
     def __init_subclass__(cls) -> None:
         try:
@@ -270,12 +273,12 @@ class TypedVersion(Version):
         return {str(key): self._flatten_object(value) for key, value in vars(self).items() if not key.startswith("_")}
 
     @classmethod
-    def from_flat_dict(cls: Type[TypedVersionT], version_dict: VersionConfig) -> TypedVersionT:
+    def from_flat_dict(cls: type[TypedVersionT], version_dict: VersionConfig) -> TypedVersionT:
         un_flattened_kwargs = {key: cls._un_flatten_object(cls._get_attribute_type(key), value) for key, value in version_dict.items()}
         return super().from_flat_dict(un_flattened_kwargs)
 
     @classmethod
-    def _flatten_object(cls, obj: Any) -> str:
+    def _flatten_object(cls, obj: object) -> str:
         """Flatten a Python object to a string depending on its type."""
         try:  # for some reason `cls._flatten_functions.get` fails on 3.12
             flatten_function = cls._flatten_functions[type(obj)]
@@ -284,18 +287,18 @@ class TypedVersion(Version):
         return flatten_function(obj)
 
     @classmethod
-    def _un_flatten_object(cls, type_: Type[T], flat_obj: str) -> T:
+    def _un_flatten_object(cls, type_: type[T], flat_obj: str) -> T:
         """Un-flatten an object from a string based on a destination type."""
         try:  # for some reason `cls._un_flatten_functions.get` fails on 3.12
-            un_flatten_function: Callable[[Type[T], str], T] = cls._un_flatten_functions[type_]
+            un_flatten_function: Callable[[type[T], str], T] = cls._un_flatten_functions[type_]
         except KeyError:
             un_flatten_function = cls._un_flatten_default
         return un_flatten_function(type_, flat_obj)
 
     @classmethod
-    def _get_attribute_type(cls, attribute_name: str) -> Type[Any]:
+    def _get_attribute_type(cls, attribute_name: str) -> type[object]:
         type_hints = get_type_hints(cls)
-        return cast(Type[Any], type_hints[attribute_name])
+        return cast(type[object], type_hints[attribute_name])
 
     @classmethod
     def flatten(cls, func: Callable[[T], str]) -> Callable[[T], str]:
@@ -315,12 +318,12 @@ class TypedVersion(Version):
             ...     return str(int(obj.timestamp()))
         """
         type_hints = get_type_hints(func)
-        obj_type: Type[T] = type_hints["obj"]
+        obj_type: type[T] = type_hints["obj"]
         cls._flatten_functions[obj_type] = func
         return func
 
     @classmethod
-    def un_flatten(cls, func: Callable[[Type[T], str], T]) -> Callable[[Type[T], str], T]:
+    def un_flatten(cls, func: Callable[[type[T], str], T]) -> Callable[[type[T], str], T]:
         """
         Register a function for un-flattening a string to a specific type.
 
@@ -338,21 +341,21 @@ class TypedVersion(Version):
             ...     return type_.fromtimestamp(int(obj))
         """
         type_hints = get_type_hints(func)
-        return_type: Type[T] = type_hints["return"]
+        return_type: type[T] = type_hints["return"]
         cls._un_flatten_functions[return_type] = func
         return func
 
     @staticmethod
-    def _flatten_default(obj: Any) -> str:
+    def _flatten_default(obj: object) -> str:
         return str(obj)
 
     @staticmethod
-    def _un_flatten_default(type_: Type[T], flat_obj: str) -> T:
+    def _un_flatten_default(type_: type[T], flat_obj: str) -> T:
         return type_(flat_obj)  # type: ignore[call-arg]
 
 
 @TypedVersion.un_flatten
-def _(type_: Type[bool], obj: str) -> bool:
+def _(type_: type[bool], obj: str) -> bool:
     return obj == "True"
 
 
@@ -362,7 +365,7 @@ def _(obj: datetime) -> str:
 
 
 @TypedVersion.un_flatten
-def _(type_: Type[datetime], obj: str) -> datetime:
+def _(type_: type[datetime], obj: str) -> datetime:
     return type_.fromtimestamp(int(obj))
 
 
@@ -372,5 +375,5 @@ def _(obj: Enum) -> str:
 
 
 @TypedVersion.un_flatten
-def _(type_: Type[Enum], obj: str) -> Enum:
+def _(type_: type[Enum], obj: str) -> Enum:
     return type_[obj]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,13 @@ For a full list see the documentation: https://www.sphinx-doc.org/en/master/usag
 """
 # -- Path setup --------------------------------------------------------------
 
-import pathlib
+from pathlib import Path
 import sys
-from typing import Optional
+from typing import Any
 
 import sphinx.config
 
-CONF_FILE_PATH = pathlib.Path(__file__).absolute()
+CONF_FILE_PATH = Path(__file__).absolute()
 SOURCE_FOLDER_PATH = CONF_FILE_PATH.parent
 DOCS_FOLDER_PATH = SOURCE_FOLDER_PATH.parent
 REPO_FOLDER_PATH = DOCS_FOLDER_PATH.parent
@@ -54,7 +54,6 @@ always_document_param_types = True
 autodoc_member_order = "bysource"
 
 autodoc_custom_types = {
-    concoursetools.typing.MultiVersionT: ":class:`~concoursetools.additional.MultiVersion`",
     concoursetools.typing.VersionT: ":class:`~concoursetools.version.Version`",
     concoursetools.typing.SortableVersionT: ":class:`~concoursetools.version.Version`",
 }
@@ -62,7 +61,7 @@ autodoc_custom_types = {
 suppress_warnings = ["config.cache"]  # https://github.com/sphinx-doc/sphinx/issues/12300#issuecomment-2062238457
 
 
-def typehints_formatter(annotation, config: sphinx.config.Config) -> Optional[str]:
+def typehints_formatter(annotation: Any, config: sphinx.config.Config) -> str | None:
     """Properly replace custom type aliases."""
     return autodoc_custom_types.get(annotation)
 

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -83,7 +83,7 @@ The Dockerfile should look something like:
 
 .. code:: Dockerfile
 
-    FROM python:3.8-alpine
+    FROM python:3.9
 
     COPY requirements.txt requirements.txt
 
@@ -118,7 +118,7 @@ If any of your requirements are private (Concourse Tools is not a public project
 
 .. code:: Dockerfile
 
-    FROM python:3.8 as builder
+    FROM python:3.9 as builder
 
     RUN apk update --no-progress && apk add openssh-client && apk add --no-cache --no-progress git
 
@@ -139,7 +139,7 @@ If any of your requirements are private (Concourse Tools is not a public project
         pip install -r requirements.txt --no-deps
 
 
-    FROM python:3.8-alpine as runner
+    FROM python:3.9-slim as runner
     COPY --from=builder /opt/venv /opt/venv
     # Activate venv
     ENV PATH="/opt/venv/bin:$PATH"

--- a/docs/source/examples/build_status.rst
+++ b/docs/source/examples/build_status.rst
@@ -119,7 +119,7 @@ Remember creating that Build Status enum? We should make use of it here:
     :end-at: {possible_values}
     :dedent:
 
-Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :obj:`sys.argv`), but is also a :class:`~pathlib.Path` instance, which makes the code a bit shorter:
+Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :obj:`sys.argv`), but is also a :class:`~Path` instance, which makes the code a bit shorter:
 
 .. literalinclude:: ../../../examples/build_status.py
     :pyobject: Resource.publish_new_version

--- a/docs/source/examples/build_status.rst
+++ b/docs/source/examples/build_status.rst
@@ -45,7 +45,7 @@ The first parameter group are the authentication parameters: ``username``, ``pas
 
 .. literalinclude:: ../../../examples/build_status.py
     :pyobject: create_auth
-    :end-at: auth = HTTPBasicAuth
+    :end-at: auth: AuthBase = HTTPBasicAuth
 
 If the user instead passes ``client_id`` and ``client_secret``, we instead need to use OAuth to fetch a bearer token. Neither of these are available natively in :mod:`requests`, and so we need to implement our own. The original resource `has the following <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/bitbucket/bitbucket.py#L39>`_:
 
@@ -119,7 +119,7 @@ Remember creating that Build Status enum? We should make use of it here:
     :end-at: {possible_values}
     :dedent:
 
-Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :obj:`sys.argv`), but is also a :class:`~Path` instance, which makes the code a bit shorter:
+Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :obj:`sys.argv`), but is also a :class:`~pathlib.Path` instance, which makes the code a bit shorter:
 
 .. literalinclude:: ../../../examples/build_status.py
     :pyobject: Resource.publish_new_version

--- a/docs/source/examples/secrets.rst
+++ b/docs/source/examples/secrets.rst
@@ -46,7 +46,7 @@ The behaviour of the resource is as follows:
 1. The metadata of the secret is fetched from AWS using `describe_secret <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/describe_secret.html>`_. The response metadata is removed, but could potentially be output as :ref:`Step Metadata`.
 2. The metadata is saved to a file. By default this is named ``metadata.json``, but the user can customise this with the parameters of the :concourse:`get-step`.
 3. If the user has requested the secret value also (which is **not** the default behaviour), then this is fetched using `get_secret_value <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/get_secret_value.html>`_ to be saved to a file, which defaults to ``value`` but is again customisable by the user.
-4. If the response contains a string, then this is written directly to the file using :meth:`~Path.write_text`, but if it contains a binary then it is instead written using :meth:`~Path.write_bytes`.
+4. If the response contains a string, then this is written directly to the file using :meth:`~pathlib.Path.write_text`, but if it contains a binary then it is instead written using :meth:`~pathlib.Path.write_bytes`.
 
 The :mod:`json` module is imported as ``json_package`` to avoid a name collision with a future argument. The metadata of the secret contains some :class:`~datetime.datetime` objects, and so a custom :class:`~json.JSONEncoder` is required:
 
@@ -63,7 +63,7 @@ The behaviour is as follows:
 
 1. If the user has specified the secret value as JSON, then encode that as a string as pass it forward.
 2. If the secret is specified as a string, then attempt to set the secret value with `put_secret_value <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/put_secret_value.html>`_.
-3. If the secret is specified as a file path, then use :meth:`~Path.read_bytes` to get the contents of the file (more resilient than reading the text) and set the ``SecretBinary`` instead.
+3. If the secret is specified as a file path, then use :meth:`~pathlib.Path.read_bytes` to get the contents of the file (more resilient than reading the text) and set the ``SecretBinary`` instead.
 4. If none of these have been set, then raise an error.
 5. Pull out the new ID from the response to establish the new version to return, and also pass the ``VersionStages`` as metadata to be output to the console.
 

--- a/docs/source/examples/secrets.rst
+++ b/docs/source/examples/secrets.rst
@@ -46,7 +46,7 @@ The behaviour of the resource is as follows:
 1. The metadata of the secret is fetched from AWS using `describe_secret <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/describe_secret.html>`_. The response metadata is removed, but could potentially be output as :ref:`Step Metadata`.
 2. The metadata is saved to a file. By default this is named ``metadata.json``, but the user can customise this with the parameters of the :concourse:`get-step`.
 3. If the user has requested the secret value also (which is **not** the default behaviour), then this is fetched using `get_secret_value <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/get_secret_value.html>`_ to be saved to a file, which defaults to ``value`` but is again customisable by the user.
-4. If the response contains a string, then this is written directly to the file using :meth:`~pathlib.Path.write_text`, but if it contains a binary then it is instead written using :meth:`~pathlib.Path.write_bytes`.
+4. If the response contains a string, then this is written directly to the file using :meth:`~Path.write_text`, but if it contains a binary then it is instead written using :meth:`~Path.write_bytes`.
 
 The :mod:`json` module is imported as ``json_package`` to avoid a name collision with a future argument. The metadata of the secret contains some :class:`~datetime.datetime` objects, and so a custom :class:`~json.JSONEncoder` is required:
 
@@ -63,7 +63,7 @@ The behaviour is as follows:
 
 1. If the user has specified the secret value as JSON, then encode that as a string as pass it forward.
 2. If the secret is specified as a string, then attempt to set the secret value with `put_secret_value <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager/client/put_secret_value.html>`_.
-3. If the secret is specified as a file path, then use :meth:`~pathlib.Path.read_bytes` to get the contents of the file (more resilient than reading the text) and set the ``SecretBinary`` instead.
+3. If the secret is specified as a file path, then use :meth:`~Path.read_bytes` to get the contents of the file (more resilient than reading the text) and set the ``SecretBinary`` instead.
 4. If none of these have been set, then raise an error.
 5. Pull out the new ID from the response to establish the new version to return, and also pass the ``VersionStages`` as metadata to be output to the console.
 

--- a/docs/source/extensions/concourse.py
+++ b/docs/source/extensions/concourse.py
@@ -12,7 +12,6 @@ Set ``concourse_base_url`` in ``conf.py`` to change the URL used. It must contai
 """
 from __future__ import annotations
 
-from typing import Any
 from urllib.parse import quote
 
 from docutils import nodes
@@ -26,7 +25,7 @@ __all__ = ("make_concourse_link", "setup")
 DEFAULT_BASE_URL = "https://concourse-ci.org/{target}"
 
 
-def make_concourse_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, Any] = {},
+def make_concourse_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, object] = {},
                         content: list[str] = []) -> tuple[list[nodes.reference], list[system_message]]:
     """
     Add a link to the given article on Concourse CI.
@@ -45,7 +44,7 @@ def make_concourse_link(name: str, rawtext: str, text: str, lineno: int, inliner
 
     :return: A list containing the created node, and a list containing any messages generated during the function.
     """
-    text = nodes.unescape(text)
+    text = nodes.unescape(text)  # type: ignore[attr-defined]
     _, title, target = split_explicit_title(text)
 
     title = title.split(".")[-1].replace("-", " ")
@@ -57,14 +56,14 @@ def make_concourse_link(name: str, rawtext: str, text: str, lineno: int, inliner
     else:
         new_target = f"{page}.html"
 
-    base_url: str = inliner.document.settings.env.config.concourse_base_url  # type: ignore
+    base_url: str = inliner.document.settings.env.config.concourse_base_url
     ref = base_url.format(target=new_target)
 
     node = nodes.reference(rawtext, title, refuri=str(ref), **options)
     return [node], []
 
 
-def setup(app: Sphinx) -> dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, object]:
     """
     Attach the extension to the application.
 

--- a/docs/source/extensions/linecount.py
+++ b/docs/source/extensions/linecount.py
@@ -10,7 +10,6 @@ This is the same  path passed to literalinclude.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from docutils import nodes
 from docutils.nodes import system_message
@@ -20,8 +19,8 @@ from sphinx.application import Sphinx
 __all__ = ("count_lines", "setup")
 
 
-def count_lines(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, Any] = {},
-                content: list[str] = []) -> tuple[list[nodes.reference], list[system_message]]:
+def count_lines(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, object] = {},
+                content: list[str] = []) -> tuple[list[nodes.Node], list[system_message]]:
     """
     Add a text node containing the number of lines.
 
@@ -39,8 +38,8 @@ def count_lines(name: str, rawtext: str, text: str, lineno: int, inliner: Inline
 
     :return: A list containing the created node, and a list containing any messages generated during the function.
     """
-    path = Path(nodes.unescape(text))
-    page_path = Path(Path(inliner.document.settings._source))  # type: ignore
+    path = Path(nodes.unescape(text))  # type: ignore[attr-defined]
+    page_path = Path(Path(inliner.document.settings._source))
     resolved_path = (page_path.parent / path).resolve()
     with open(resolved_path) as rf:
         line_count = sum(1 for _ in rf)
@@ -49,7 +48,7 @@ def count_lines(name: str, rawtext: str, text: str, lineno: int, inliner: Inline
     return [node], []
 
 
-def setup(app: Sphinx) -> dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, object]:
     """
     Attach the extension to the application.
 

--- a/docs/source/extensions/wikipedia.py
+++ b/docs/source/extensions/wikipedia.py
@@ -34,7 +34,7 @@ def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner
     :param rawtext: A string containing the entire interpreted text input, including the role and markup.
     :param text: The interpreted text content.
     :param lineno: The line number where the interpreted text begins.
-    :param inliner: The :class:`docutils.parsers.rst.states.Inliner` object that called :func:`~.source_role`.
+    :param inliner: The :class:`docutils.parsers.rst.states.Inliner` object that called ``source_role``.
                     It contains the several attributes useful for error reporting and document tree access.
     :param options: A dictionary of directive options for customization (from the ``role`` directive),
                     to be interpreted by the function. Used for additional attributes for the generated elements
@@ -55,7 +55,7 @@ def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner
         lang = inliner.document.settings.env.config.wikipedia_lang
 
     base_url: str = inliner.document.settings.env.config.wikipedia_base_url
-    ref = base_url.format(lang=lang, target=quote(target.replace(" ", "_"), safe=""))
+    ref = base_url.format(lang=lang, target=quote(target.replace(" ", "_"), safe="#"))
 
     node = nodes.reference(rawtext, title, refuri=str(ref), **options)
     return [node], []

--- a/docs/source/extensions/wikipedia.py
+++ b/docs/source/extensions/wikipedia.py
@@ -11,7 +11,6 @@ It can also contain "{lang}" to allow the language code (e.g. "de") to be inject
 from __future__ import annotations
 
 import re
-from typing import Any
 from urllib.parse import quote
 
 from docutils import nodes
@@ -26,7 +25,7 @@ DEFAULT_BASE_URL = "https://{lang}.wikipedia.org/wiki/{target}"
 RE_WIKI_LANG = re.compile(":(.*?):(.*)")
 
 
-def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, Any] = {},
+def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner, options: dict[str, object] = {},
                         content: list[str] = []) -> tuple[list[nodes.reference], list[system_message]]:
     """
     Add a link to the given article on :wikipedia:`Wikipedia`.
@@ -45,7 +44,7 @@ def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner
 
     :return: A list containing the created node, and a list containing any messages generated during the function.
     """
-    text = nodes.unescape(text)
+    text = nodes.unescape(text)  # type: ignore[attr-defined]
     has_explicit, title, target = split_explicit_title(text)
 
     if (match := RE_WIKI_LANG.match(target)):
@@ -53,16 +52,16 @@ def make_wikipedia_link(name: str, rawtext: str, text: str, lineno: int, inliner
         if not has_explicit:
             title = target
     else:  # default language
-        lang: str = inliner.document.settings.env.config.wikipedia_lang  # type: ignore
+        lang = inliner.document.settings.env.config.wikipedia_lang
 
-    base_url: str = inliner.document.settings.env.config.wikipedia_base_url  # type: ignore
+    base_url: str = inliner.document.settings.env.config.wikipedia_base_url
     ref = base_url.format(lang=lang, target=quote(target.replace(" ", "_"), safe=""))
 
     node = nodes.reference(rawtext, title, refuri=str(ref), **options)
     return [node], []
 
 
-def setup(app: Sphinx) -> dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, object]:
     """
     Attach the extension to the application.
 

--- a/docs/source/extensions/xkcd.py
+++ b/docs/source/extensions/xkcd.py
@@ -12,7 +12,9 @@ In addition:
 
 Set ``xkcd_endpoint`` in ``conf.py`` to change the URL used.
 """
-from typing import Any, Dict, List, Tuple
+from __future__ import annotations
+
+from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -44,9 +46,9 @@ class XkcdDirective(SphinxDirective):
     @property
     def config(self) -> BuildEnvironment:
         """Return the config environment."""
-        return self.state.document.settings.env.config  # type: ignore[no-any-return]
+        return self.state.document.settings.env.config
 
-    def run(self) -> List[nodes.Node]:
+    def run(self) -> list[nodes.Node]:
         """
         Process the content of the shield directive.
         """
@@ -70,7 +72,7 @@ class XkcdDirective(SphinxDirective):
         figure_node += caption_node
         return [figure_node]
 
-    def get_comic_info(self, comic_number: int, endpoint: str = DEFAULT_XKCD) -> Dict[str, Any]:
+    def get_comic_info(self, comic_number: int, endpoint: str = DEFAULT_XKCD) -> dict[str, Any]:
         comic_link = f"{endpoint}/{comic_number}/"
         try:
             response = requests.get(f"{endpoint}/{comic_number}/info.0.json")
@@ -78,14 +80,14 @@ class XkcdDirective(SphinxDirective):
         except requests.ConnectionError:
             logger = logging.getLogger(__name__)
             logger.warning("Could not connect to xkcd endpoint")
-            response_json: Dict[str, Any] = {
+            response_json: dict[str, object] = {
                 "img": comic_link,
                 "alt": comic_link,
             }
         except requests.HTTPError:
             latest_response = requests.get(f"{endpoint}/info.0.json")
-            latest_json: Dict[str, Any] = latest_response.json()
-            most_recent_comic = latest_json["num"]
+            latest_json: dict[str, Any] = latest_response.json()
+            most_recent_comic: int = latest_json["num"]
             if most_recent_comic < comic_number:
                 raise ValueError(f"You asked for xkcd #{comic_number}, but the most recent available comic is #{most_recent_comic}")
             else:
@@ -97,7 +99,7 @@ class XkcdDirective(SphinxDirective):
 
 
 def make_xkcd_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inliner,
-                   options: Dict[str, Any] = {}, content: List[str] = []) -> Tuple[List[nodes.reference], List[nodes.system_message]]:
+                   options: dict[str, object] = {}, content: list[str] = []) -> tuple[list[nodes.reference], list[nodes.system_message]]:
     """
     Add a link to a page on the xkcd website.
 
@@ -115,17 +117,17 @@ def make_xkcd_link(name: str, rawtext: str, text: str, lineno: int, inliner: Inl
 
     :return: A list containing the created node, and a list containing any messages generated during the function.
     """
-    text = nodes.unescape(text)
+    text = nodes.unescape(text)  # type: ignore[attr-defined]
     _, title, target = split_explicit_title(text)
 
-    endpoint: str = inliner.document.settings.env.config.xkcd_endpoint  # type: ignore
+    endpoint: str = inliner.document.settings.env.config.xkcd_endpoint
     ref = f"{endpoint}/{target}"
 
     node = nodes.reference(rawtext, title, refuri=str(ref), **options)
     return [node], []
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, object]:
     """
     Attach the extension to the application.
 

--- a/docs/source/typing.rst
+++ b/docs/source/typing.rst
@@ -28,8 +28,6 @@ Type Vars
 
 .. autodata:: concoursetools.typing.SortableVersionT
 
-.. autodata:: concoursetools.typing.MultiVersionT
-
 Protocols
 ---------
 
@@ -38,5 +36,3 @@ Protocols
 .. autoclass:: concoursetools.typing.TypedVersionProtocol
 
 .. autoclass:: concoursetools.typing.SortableVersionProtocol
-
-.. autoclass:: concoursetools.typing.MultiVersionProtocol

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -24,7 +24,7 @@ Concourse Tools has out-of-the-box support for a few common types:
 * :class:`~datetime.datetime`: The datetime object is mapped to an integer timestamp.
 * :class:`bool`: The boolean is mapped to the strings ``"True"`` or ``"False"``.
 * :class:`~enum.Enum`: Enums are mapped to their *names*, so ``MyEnum.ONE`` maps to ``ONE``.
-* :class:`~Path`: Paths are mapped to their string representations.
+* :class:`~pathlib.Path`: Paths are mapped to their string representations.
 
 
 Version Comparisons

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -24,7 +24,7 @@ Concourse Tools has out-of-the-box support for a few common types:
 * :class:`~datetime.datetime`: The datetime object is mapped to an integer timestamp.
 * :class:`bool`: The boolean is mapped to the strings ``"True"`` or ``"False"``.
 * :class:`~enum.Enum`: Enums are mapped to their *names*, so ``MyEnum.ONE`` maps to ``ONE``.
-* :class:`~pathlib.Path`: Paths are mapped to their string representations.
+* :class:`~Path`: Paths are mapped to their string representations.
 
 
 Version Comparisons

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+# (C) Crown Copyright GCHQ

--- a/examples/build_status.py
+++ b/examples/build_status.py
@@ -1,9 +1,11 @@
 # (C) Crown Copyright GCHQ
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum, auto
-import pathlib
+from pathlib import Path
 import subprocess
-from typing import Optional, Tuple
+from typing import Any
 
 import requests
 from requests.auth import AuthBase, HTTPBasicAuth
@@ -39,7 +41,7 @@ class BitbucketOAuth(AuthBase):
         return request
 
     @classmethod
-    def from_client_credentials(cls, client_id: str, client_secret: str):
+    def from_client_credentials(cls, client_id: str, client_secret: str) -> "BitbucketOAuth":
         token_auth = HTTPBasicAuth(client_id, client_secret)
 
         url = "https://bitbucket.org/site/oauth2/access_token"
@@ -56,11 +58,11 @@ class Version(TypedVersion):
     build_status: BuildStatus
 
 
-class Resource(OutOnlyConcourseResource):
+class Resource(OutOnlyConcourseResource[Version]):
 
-    def __init__(self, repository: Optional[str] = None, endpoint: Optional[str] = None,
-                 username: Optional[str] = None, password: Optional[str] = None,
-                 client_id: Optional[str] = None, client_secret: Optional[str] = None,
+    def __init__(self, repository: str | None = None, endpoint: str | None = None,
+                 username: str | None = None, password: str | None = None,
+                 client_id: str | None = None, client_secret: str | None = None,
                  verify_ssl: bool = True, driver: str = "Bitbucket Server",
                  debug: bool = False) -> None:
         super().__init__(Version)
@@ -89,11 +91,11 @@ class Resource(OutOnlyConcourseResource):
             if repository is None:
                 raise ValueError("Must set repository when using Bitbucket Cloud.")
 
-    def publish_new_version(self, sources_dir: pathlib.Path, build_metadata: BuildMetadata,
-                            repository: str, build_status: str, key: Optional[str] = None,
-                            name: Optional[str] = None, build_url: Optional[str] = None,
-                            description: Optional[str] = None,
-                            commit_hash: Optional[str] = None) -> Tuple[Version, Metadata]:
+    def publish_new_version(self, sources_dir: Path, build_metadata: BuildMetadata,
+                            repository: str, build_status: str, key: str | None = None,
+                            name: str | None = None, build_url: str | None = None,
+                            description: str | None = None,
+                            commit_hash: str | None = None) -> tuple[Version, Metadata]:
         self.debug("--DEBUG MODE--")
 
         try:
@@ -167,17 +169,17 @@ class Resource(OutOnlyConcourseResource):
         }
         return version, metadata
 
-    def debug(self, *args, colour=Colour.CYAN, **kwargs):
+    def debug(self, *args: object, colour: str = Colour.CYAN, **kwargs: Any) -> None:
         if self._debug:
             colour_print(*args, colour=colour, **kwargs)
 
 
-def create_auth(username: Optional[str] = None,
-                password: Optional[str] = None,
-                client_id: Optional[str] = None,
-                client_secret: Optional[str] = None) -> AuthBase:
+def create_auth(username: str | None = None,
+                password: str | None = None,
+                client_id: str | None = None,
+                client_secret: str | None = None) -> AuthBase:
     if username is not None and password is not None:
-        auth = HTTPBasicAuth(username, password)
+        auth: AuthBase = HTTPBasicAuth(username, password)
     elif client_id is not None and client_secret is not None:
         auth = BitbucketOAuth.from_client_credentials(client_id, client_secret)
     else:

--- a/examples/github_branches.py
+++ b/examples/github_branches.py
@@ -1,7 +1,8 @@
 # (C) Crown Copyright GCHQ
+from __future__ import annotations
+
 from dataclasses import dataclass
 import re
-from typing import Set
 
 import requests
 
@@ -14,9 +15,9 @@ class BranchVersion(TypedVersion):
     name: str
 
 
-class Resource(MultiVersionConcourseResource):
+class Resource(MultiVersionConcourseResource[BranchVersion]):  # type: ignore[type-var]
     def __init__(self, owner: str, repo: str, regex: str = ".*",
-                 endpoint: str = "https://api.github.com"):
+                 endpoint: str = "https://api.github.com") -> None:
         """
         Initialise self.
 
@@ -30,7 +31,7 @@ class Resource(MultiVersionConcourseResource):
         self.api_route = f"{endpoint}/repos/{owner}/{repo}/branches"
         self.regex = re.compile(regex)
 
-    def fetch_latest_sub_versions(self) -> Set[BranchVersion]:
+    def fetch_latest_sub_versions(self) -> set[BranchVersion]:
         headers = {"Accept": "application/vnd.github+json"}
         response = requests.get(self.api_route, headers=headers)
         branches_info = response.json()

--- a/examples/s3.py
+++ b/examples/s3.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
-import pathlib
+from pathlib import Path
 
 import boto3
 from botocore.client import Config
 
+from concoursetools import BuildMetadata
 from concoursetools.additional import InOnlyConcourseResource
 
 
@@ -14,7 +15,7 @@ class S3SignedURLConcourseResource(InOnlyConcourseResource):
     """
     A Concourse resource type for generating pre-signed URLs for items in S3 buckets.
     """
-    def __init__(self, bucket_name: str, region_name: str):
+    def __init__(self, bucket_name: str, region_name: str) -> None:
         """
         Initialise self.
 
@@ -26,10 +27,10 @@ class S3SignedURLConcourseResource(InOnlyConcourseResource):
         self.client = boto3.client("s3", region_name=region_name,
                                    config=Config(signature_version="s3v4"))
 
-    def download_data(self, destination_dir: pathlib.Path, build_metadata,
-                      file_path: str, expires_in: dict,
+    def download_data(self, destination_dir: Path, build_metadata: BuildMetadata,
+                      file_path: str, expires_in: dict[str, float],
                       file_name: str | None = None,
-                      url_file: str = "url"):
+                      url_file: str = "url") -> dict[str, str]:
         params = {
             "Bucket": self.bucket_name,
             "Key": file_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ force_sort_within_sections = true
 
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 check_untyped_defs = true
 disallow_untyped_defs = true
 warn_redundant_casts = true
@@ -27,7 +27,6 @@ warn_unused_ignores = true
 warn_return_any = true
 disallow_any_generics = true
 disable_error_code = ["override"]
-exclude = ["docs/source/conf.py", "examples", "setup.py"]
 
 
 [tool.pylint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Natural Language :: English
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -31,7 +30,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=3.8
+python_requires = >=3.9
 packages =
     concoursetools
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectDescription="Static analysis for the Concourse Tools Python library
 sonar.sources=concoursetools
 sonar.tests=tests
 
-sonar.python.version=3.8,3.9,3.10,3.11,3.12
+sonar.python.version=3.9,3.10,3.11,3.12
 
 sonar.coverage.exclusions=docs/**/*,tests/**/*,coverage.xml,concoursetools/colour.py,concoursetools/typing.py,**/__init__.py,**/__main__.py
 sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -2,10 +2,11 @@
 """
 Contains a test resource.
 """
+from __future__ import annotations
+
 from copy import copy
 from dataclasses import dataclass
-import pathlib
-from typing import Any, List, Optional, Tuple, Type
+from pathlib import Path
 
 import concoursetools
 from concoursetools.metadata import BuildMetadata
@@ -20,21 +21,21 @@ class TestVersion(concoursetools.Version):
 
 class TestResource(concoursetools.ConcourseResource[TestVersion]):
 
-    def __init__(self, uri: str, branch: str = "main", private_key: Optional[str] = None):
+    def __init__(self, uri: str, branch: str = "main", private_key: str | None = None):
         super().__init__(TestVersion)
         self.uri = uri
         self.branch = branch
         self.private_key = private_key
 
-    def fetch_new_versions(self, previous_version: Optional[TestVersion] = None) -> List[TestVersion]:
+    def fetch_new_versions(self, previous_version: TestVersion | None = None) -> list[TestVersion]:
         if previous_version:
             print("Previous version found.")
             return [TestVersion("7154fe")]
         else:
             return [TestVersion(ref) for ref in ("61cbef", "d74e01", "7154fe")]
 
-    def download_version(self, version: TestVersion, destination_dir: pathlib.Path, build_metadata: concoursetools.BuildMetadata,
-                         file_name: str = "README.txt") -> Tuple[TestVersion, Metadata]:
+    def download_version(self, version: TestVersion, destination_dir: Path, build_metadata: concoursetools.BuildMetadata,
+                         file_name: str = "README.txt") -> tuple[TestVersion, Metadata]:
         print("Downloading.")
         readme_path = destination_dir / file_name
         readme_path.write_text(f"Downloaded README for ref {version.ref}.\n")
@@ -43,8 +44,8 @@ class TestResource(concoursetools.ConcourseResource[TestVersion]):
         }
         return version, metadata
 
-    def publish_new_version(self, sources_dir: pathlib.Path, build_metadata: concoursetools.BuildMetadata, repo: str,
-                            ref_file: str = "ref.txt") -> Tuple[TestVersion, Metadata]:
+    def publish_new_version(self, sources_dir: Path, build_metadata: concoursetools.BuildMetadata, repo: str,
+                            ref_file: str = "ref.txt") -> tuple[TestVersion, Metadata]:
         ref_path = sources_dir / repo / ref_file
         ref = ref_path.read_text()
         print("Uploading.")
@@ -67,21 +68,21 @@ def _(obj: bool) -> str:
 
 
 @ConcourseMockVersion.un_flatten
-def _(_type: Type[bool], obj: str) -> bool:
+def _(_type: type[bool], obj: str) -> bool:
     return obj == "true"
 
 
 class ConcourseMockResource(concoursetools.ConcourseResource[ConcourseMockVersion]):
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: object) -> None:
         super().__init__(ConcourseMockVersion)
 
-    def fetch_new_versions(self, previous_version: Optional[ConcourseMockVersion] = None) -> List[ConcourseMockVersion]:
+    def fetch_new_versions(self, previous_version: ConcourseMockVersion | None = None) -> list[ConcourseMockVersion]:
         raise NotImplementedError
 
-    def download_version(self, version: ConcourseMockVersion, destination_dir: pathlib.Path,
-                         build_metadata: BuildMetadata) -> Tuple[ConcourseMockVersion, Metadata]:
+    def download_version(self, version: ConcourseMockVersion, destination_dir: Path,
+                         build_metadata: BuildMetadata) -> tuple[ConcourseMockVersion, Metadata]:
         raise NotImplementedError
 
-    def publish_new_version(self, sources_dir: pathlib.Path, build_metadata: BuildMetadata) -> Tuple[ConcourseMockVersion, Metadata]:
+    def publish_new_version(self, sources_dir: Path, build_metadata: BuildMetadata) -> tuple[ConcourseMockVersion, Metadata]:
         raise NotImplementedError

--- a/tests/test_dockertools.py
+++ b/tests/test_dockertools.py
@@ -2,7 +2,7 @@
 """
 Tests for the dockertools module.
 """
-import pathlib
+from pathlib import Path
 import shutil
 import sys
 from tempfile import TemporaryDirectory
@@ -20,18 +20,18 @@ class BasicTests(TestCase):
     Tests for the utility functions.
     """
     def test_import_path_creation(self) -> None:
-        file_path = pathlib.Path("path/to/python.py")
+        file_path = Path("path/to/python.py")
         import_path = file_path_to_import_path(file_path)
         self.assertEqual(import_path, "path.to.python")
 
     def test_import_path_creation_wrong_extension(self) -> None:
-        file_path = pathlib.Path("path/to/file.txt")
+        file_path = Path("path/to/file.txt")
         with self.assertRaises(ValueError):
             file_path_to_import_path(file_path)
 
     def test_importing_classes(self) -> None:
-        file_path = pathlib.Path(additional.__file__).relative_to(pathlib.Path.cwd())
-        resource_classes = import_resource_classes_from_module(file_path)
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
+        resource_classes = import_resource_classes_from_module(file_path)  # type: ignore[var-annotated]
         expected = {
             "InOnlyConcourseResource": additional.InOnlyConcourseResource,
             "OutOnlyConcourseResource": additional.OutOnlyConcourseResource,
@@ -42,29 +42,30 @@ class BasicTests(TestCase):
         self.assertDictEqual(resource_classes, expected)
 
     def test_importing_class_no_name(self) -> None:
-        file_path = pathlib.Path(test_resource.__file__).relative_to(pathlib.Path.cwd())
+        file_path = Path(test_resource.__file__).relative_to(Path.cwd())
         with self.assertRaises(RuntimeError):
             import_resource_class_from_module(file_path)
 
     def test_importing_class_with_name(self) -> None:
-        file_path = pathlib.Path(test_resource.__file__).relative_to(pathlib.Path.cwd())
-        resource_class = import_resource_class_from_module(file_path, class_name=test_resource.TestResource.__name__)
+        file_path = Path(test_resource.__file__).relative_to(Path.cwd())
+        resource_class = import_resource_class_from_module(file_path, class_name=test_resource.TestResource.__name__)  # type: ignore[var-annotated]
         self.assertEqual(resource_class, test_resource.TestResource)
 
     def test_importing_class_no_options(self) -> None:
-        file_path = pathlib.Path("pathlib.py")
+        file_path = Path("pathlib.py")
         with self.assertRaises(RuntimeError):
             import_resource_class_from_module(file_path)
 
     def test_importing_class_multiple_options(self) -> None:
-        file_path = pathlib.Path(additional.__file__).relative_to(pathlib.Path.cwd())
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
         with self.assertRaises(RuntimeError):
             import_resource_class_from_module(file_path)
 
     def test_importing_class_multiple_options_specify_name(self) -> None:
-        file_path = pathlib.Path(additional.__file__).relative_to(pathlib.Path.cwd())
-        resource_class = import_resource_class_from_module(file_path, class_name=additional.InOnlyConcourseResource.__name__)
-        self.assertEqual(resource_class, additional.InOnlyConcourseResource)
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
+        parent_class = additional.InOnlyConcourseResource
+        resource_class = import_resource_class_from_module(file_path, class_name=parent_class.__name__)  # type: ignore[var-annotated]
+        self.assertEqual(resource_class, parent_class)
 
 
 class DockerTests(TestCase):
@@ -74,9 +75,9 @@ class DockerTests(TestCase):
     def setUp(self) -> None:
         """Code to run before each test."""
         self._temp_dir = TemporaryDirectory()
-        self.temp_dir = pathlib.Path(self._temp_dir.name)
+        self.temp_dir = Path(self._temp_dir.name)
 
-        path_to_this_file = pathlib.Path(__file__)
+        path_to_this_file = Path(__file__)
         path_to_test_resource_module = path_to_this_file.parent / "resource.py"
         shutil.copyfile(path_to_test_resource_module, self.temp_dir / "concourse.py")
         self.args = Namespace(str(self.temp_dir), resource_file="concourse.py")

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,7 +1,7 @@
 # (C) Crown Copyright GCHQ
 import re
 import textwrap
-from typing import cast
+from typing import Any, cast
 from unittest import TestCase
 
 from concoursetools.parsing import format_check_output, format_in_out_output, parse_check_payload, parse_in_payload, parse_out_payload
@@ -291,7 +291,7 @@ class FormatTests(TestCase):
         self.assertEqual(expected_output, format_check_output(versions, separators=(",", ":")))
 
     def test_check_format_not_strings(self) -> None:
-        versions = [
+        versions: list[dict[str, Any]] = [
             {"ref": 100},
             {"ref": True},
             {"ref": None},
@@ -303,7 +303,7 @@ class FormatTests(TestCase):
             { "ref": "None" }
         ]
         """)
-        self.assertEqual(expected_output, format_check_output(versions, separators=(",", ":")))  # type: ignore[arg-type]
+        self.assertEqual(expected_output, format_check_output(versions, separators=(",", ":")))
 
     def test_in_out_format(self) -> None:
         version = {"ref": "61cebf"}
@@ -323,8 +323,8 @@ class FormatTests(TestCase):
         self.assertEqual(expected_output, format_in_out_output(version, metadata, separators=(",", ":")))
 
     def test_in_out_format_not_strings(self) -> None:
-        version = {"ref": True}
-        metadata = {
+        version: dict[str, Any] = {"ref": True}
+        metadata: dict[str, Any] = {
             "commit": 100,
             "author": "HulkHogan",
         }
@@ -337,4 +337,4 @@ class FormatTests(TestCase):
             ]
         }
         """)
-        self.assertEqual(expected_output, format_in_out_output(version, metadata, separators=(",", ":")))  # type: ignore[arg-type]
+        self.assertEqual(expected_output, format_in_out_output(version, metadata, separators=(",", ":")))

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,5 +1,5 @@
 # (C) Crown Copyright GCHQ
-import pathlib
+from pathlib import Path
 import random
 import shutil
 import string
@@ -297,14 +297,14 @@ class FileWrapperTests(TestCase):
     def setUp(self) -> None:
         """Code to run before each test."""
         self.temp_dir = TemporaryDirectory()
-        create_asset_scripts(pathlib.Path(self.temp_dir.name), TestResource, executable="/usr/bin/env python3")
+        create_asset_scripts(Path(self.temp_dir.name), TestResource, executable="/usr/bin/env python3")
 
         config = {
             "uri": "git://some-uri",
             "branch": "develop",
             "private_key": "...",
         }
-        self.wrapper = FileTestResourceWrapper.from_assets_dir(config, pathlib.Path(self.temp_dir.name))
+        self.wrapper = FileTestResourceWrapper.from_assets_dir(config, Path(self.temp_dir.name))
 
     def tearDown(self) -> None:
         """Code to run after each test."""
@@ -705,8 +705,8 @@ class DockerConversionWrapperTests(TestCase):
 
 def _build_test_resource_docker_image() -> str:
     with TemporaryDirectory() as temp_dir_name:
-        temp_dir = pathlib.Path(temp_dir_name)
-        path_to_this_file = pathlib.Path(__file__)
+        temp_dir = Path(temp_dir_name)
+        path_to_this_file = Path(__file__)
         path_to_test_resource_module = path_to_this_file.parent / "resource.py"
 
         temporary_resource_file = temp_dir / "concourse.py"
@@ -718,7 +718,7 @@ def _build_test_resource_docker_image() -> str:
         temp_repo_path = temp_dir / "concoursetools"
         temp_concoursetools_path = temp_repo_path / "concoursetools"
 
-        concoursetools_path = pathlib.Path(concoursetools.__file__).parent
+        concoursetools_path = Path(concoursetools.__file__).parent
         shutil.copytree(concoursetools_path, temp_concoursetools_path)
 
         for setup_file in ("setup.py", "setup.cfg", "pyproject.toml"):
@@ -728,7 +728,7 @@ def _build_test_resource_docker_image() -> str:
                 pass
 
         args = Namespace(str(temp_dir), resource_file="concourse.py", class_name=TestResource.__name__)
-        create_dockerfile(args, concoursetools_path=pathlib.Path("concoursetools"))
+        create_dockerfile(args, concoursetools_path=Path("concoursetools"))
 
         stdout, _ = run_command("docker", ["build", ".", "-q"], cwd=temp_dir)
         sha1_hash = stdout.strip()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,27 +1,30 @@
 # (C) Crown Copyright GCHQ
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import ClassVar
 from unittest import TestCase
 
 from concoursetools.testing import TemporaryDirectoryState
 
 
 class FolderDictReadTests(TestCase):
+    temp_dir: ClassVar[TemporaryDirectory[str]]
+    root: ClassVar[Path]
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.temp_dir = TemporaryDirectory()  # type: ignore[attr-defined]
-        cls.root = Path(cls.temp_dir.name)  # type: ignore[attr-defined]
+        cls.temp_dir = TemporaryDirectory()
+        cls.root = Path(cls.temp_dir.name)
 
-        folder_1 = cls.root / "folder_1"  # type: ignore[attr-defined]
-        folder_2 = cls.root / "folder_2"  # type: ignore[attr-defined]
+        folder_1 = cls.root / "folder_1"
+        folder_2 = cls.root / "folder_2"
         folder_3 = folder_2 / "folder_3"
 
         folder_1.mkdir()
         folder_2.mkdir()
         folder_3.mkdir()
 
-        file_1 = cls.root / "file_1"  # type: ignore[attr-defined]
+        file_1 = cls.root / "file_1"
         file_2 = folder_2 / "file_2"
         file_3 = folder_3 / "file_3"
 
@@ -31,10 +34,10 @@ class FolderDictReadTests(TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls.temp_dir.cleanup()  # type: ignore[attr-defined]
+        cls.temp_dir.cleanup()
 
     def test_folder_dict_depth_1(self) -> None:
-        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=1)  # type: ignore[attr-defined]
+        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=1)
         expected = {
             "folder_1": ...,
             "folder_2": ...,
@@ -43,7 +46,7 @@ class FolderDictReadTests(TestCase):
         self.assertDictEqual(folder_dict, expected)
 
     def test_folder_dict_depth_2(self) -> None:
-        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=2)  # type: ignore[attr-defined]
+        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=2)
         expected = {
             "folder_1": {},
             "folder_2": {
@@ -55,7 +58,7 @@ class FolderDictReadTests(TestCase):
         self.assertDictEqual(folder_dict, expected)
 
     def test_folder_dict_depth_3(self) -> None:
-        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=3)  # type: ignore[attr-defined]
+        folder_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=3)
         expected = {
             "folder_1": {},
             "folder_2": {
@@ -70,15 +73,17 @@ class FolderDictReadTests(TestCase):
 
 
 class FolderDictWriteTests(TestCase):
+    temp_dir: ClassVar[TemporaryDirectory[str]]
+    root: ClassVar[Path]
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.temp_dir = TemporaryDirectory()  # type: ignore[attr-defined]
-        cls.root = Path(cls.temp_dir.name)  # type: ignore[attr-defined]
+        cls.temp_dir = TemporaryDirectory()
+        cls.root = Path(cls.temp_dir.name)
 
     @classmethod
     def tearDownClass(cls) -> None:
-        cls.temp_dir.cleanup()  # type: ignore[attr-defined]
+        cls.temp_dir.cleanup()
 
     def test_folder_dict_depth_3(self) -> None:
         original = {
@@ -91,6 +96,6 @@ class FolderDictWriteTests(TestCase):
             },
             "file_1": "Testing 1\n",
         }
-        TemporaryDirectoryState()._set_folder_from_dict(self.root, original)  # type: ignore[attr-defined]
-        final_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=3)  # type: ignore[attr-defined]
+        TemporaryDirectoryState()._set_folder_from_dict(self.root, original)
+        final_dict = TemporaryDirectoryState()._get_folder_as_dict(self.root, max_depth=3)
         self.assertDictEqual(final_dict, original)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,5 +1,5 @@
 # (C) Crown Copyright GCHQ
-import pathlib
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
 
@@ -11,7 +11,7 @@ class FolderDictReadTests(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.temp_dir = TemporaryDirectory()  # type: ignore[attr-defined]
-        cls.root = pathlib.Path(cls.temp_dir.name)  # type: ignore[attr-defined]
+        cls.root = Path(cls.temp_dir.name)  # type: ignore[attr-defined]
 
         folder_1 = cls.root / "folder_1"  # type: ignore[attr-defined]
         folder_2 = cls.root / "folder_2"  # type: ignore[attr-defined]
@@ -74,7 +74,7 @@ class FolderDictWriteTests(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.temp_dir = TemporaryDirectory()  # type: ignore[attr-defined]
-        cls.root = pathlib.Path(cls.temp_dir.name)  # type: ignore[attr-defined]
+        cls.root = Path(cls.temp_dir.name)  # type: ignore[attr-defined]
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,8 +2,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-import pathlib
-from typing import Any
+from pathlib import Path
 from unittest import TestCase
 
 from concoursetools import Version
@@ -28,15 +27,19 @@ class CreationTests(TestCase):
 
 class ComplexVersion(BasicVersion, SortableVersionMixin):
 
-    def __eq__(self, other: Any) -> bool:
-        return bool(self.file_name == other.file_name)
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.file_name == other.file_name
 
-    def __lt__(self, other: Any) -> bool:
-        return bool(self.file_path < other.file_path)
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.file_path < other.file_path
 
     @property
     def file_name(self) -> str:
-        return pathlib.Path(self.file_path).name
+        return Path(self.file_path).name
 
 
 class ComparisonTests(TestCase):
@@ -51,8 +54,10 @@ class ComparisonTests(TestCase):
             def __init__(self, file_path: str) -> None:
                 self.file_path = file_path
 
-            def __lt__(self, other: Any) -> bool:
-                return bool(self.file_path < other.file_path)
+            def __lt__(self, other: object) -> bool:
+                if not isinstance(other, type(self)):
+                    return NotImplemented
+                return self.file_path < other.file_path
 
         self.assertLess(MyVersion("aaa"), MyVersion("bbb"))
 
@@ -70,8 +75,10 @@ class ComparisonTests(TestCase):
         class MyTypedVersion(TypedVersion, SortableVersionMixin):
             file_path: str
 
-            def __lt__(self, other: Any) -> bool:
-                return bool(self.file_path < other.file_path)
+            def __lt__(self, other: object) -> bool:
+                if not isinstance(other, type(self)):
+                    return NotImplemented
+                return self.file_path < other.file_path
 
         self.assertLess(MyTypedVersion("aaa"), MyTypedVersion("bbb"))
 
@@ -203,7 +210,7 @@ class TypedTests(TestCase):
             "False": False,
             "1577881800": datetime(2020, 1, 1, 12, 30),
             "ONE": MyEnum.ONE,
-            "/path/to/somewhere": pathlib.Path("/path/to/somewhere"),
+            "/path/to/somewhere": Path("/path/to/somewhere"),
         }
         for flattened_obj, obj in expected.items():
             with self.subTest(obj=obj):


### PR DESCRIPTION
* Replaced all deprecated type hints with current ones, and added `from __future__ import annotations` where appropriate.
* Added MyPy pre-commit hook

This diff is quite big, but that's due to changes to almost every type hint across the codebase.

Recommend squashing these commits.