### PR TITLE
Improved CLI

### DIFF
--- a/concoursetools/__main__.py
+++ b/concoursetools/__main__.py
@@ -1,57 +1,18 @@
 # (C) Crown Copyright GCHQ
 """
-Create the correct entry scripts for the Concourse resource.
+The main entrypoint for the Concourse Tools CLI:
 
-Once you have copied the resource module across to /opt/resource in your Dockerfile,
-change to within the directory and run the following to create the asset scripts:
-
-    python3 -m concoursetools /opt/resource
-
-Alternatively, create a skeleton Dockerfile with the following:
-
-    python3 -m concoursetools --docker .
-
-To see additional options, run:
-
-    python3 -m concoursetools -h
+    $ python3 -m concoursetools --help
 """
-from __future__ import annotations
-
-import argparse
-from pathlib import Path
 import sys
 
-from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile, import_resource_class_from_module
+from concoursetools.cli import cli
 
 
-def main(args: list[str] = sys.argv[1:]) -> None:  # pylint: disable=dangerous-default-value
+def main() -> int:
     """Run the main function."""
-    parsed_args = parse_args(args)
-    if parsed_args.docker:
-        create_dockerfile(parsed_args)
-        return
-
-    resource_class = import_resource_class_from_module(parsed_args.resource_path, parsed_args.class_name)  # type: ignore[var-annotated]
-    create_asset_scripts(Path(parsed_args.path), resource_class, parsed_args.executable)
-
-
-def parse_args(args: list[str]) -> Namespace:
-    """Parse command line args."""
-    parser = argparse.ArgumentParser()
-    parser.add_argument("path", type=str, help="The location at which to place the scripts")
-    parser.add_argument("-e", "--executable", type=str, default="/usr/bin/env python3",
-                        help="The python executable to place at the top of the file")
-    parser.add_argument("-r", "--resource-file", type=str, default="concourse.py",
-                        help="The path to the module containing the resource class")
-    parser.add_argument("-c", "--class-name", type=str,
-                        help="The name of the resource class in the module, if there are multiple")
-    parser.add_argument("--docker", action="store_true",
-                        help="Pass to create a skeleton Dockerfile at the path instead")
-    parser.add_argument("--include-rsa", action="store_true",
-                        help="Enable the Dockerfile to (securely) use your RSA private key during building")
-    parsed_args = parser.parse_args(args)
-    namespace = Namespace(**dict(parsed_args._get_kwargs()))
-    return namespace
+    cli.invoke(sys.argv[1:])
+    return 0
 
 
 if __name__ == "__main__":

--- a/concoursetools/cli/__init__.py
+++ b/concoursetools/cli/__init__.py
@@ -1,0 +1,7 @@
+# (C) Crown Copyright GCHQ
+"""
+Contains the Concourse Tools CLI.
+"""
+from concoursetools.cli.commands import cli
+
+__all__ = ("cli",)

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -7,7 +7,9 @@ import textwrap
 
 from concoursetools.cli.parser import CLI
 from concoursetools.colour import Colour, colour_print
-from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile, import_resource_class_from_module
+from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile
+from concoursetools.importing import import_single_class_from_module
+from concoursetools.resource import ConcourseResource
 
 cli = CLI()
 
@@ -36,5 +38,6 @@ def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
         create_dockerfile(parsed_args)
         return
 
-    resource_class = import_resource_class_from_module(parsed_args.resource_path, parsed_args.class_name)  # type: ignore[var-annotated]
+    resource_class = import_single_class_from_module(parsed_args.resource_path, parent_class=ConcourseResource,  # type: ignore[type-abstract]
+                                                     class_name=parsed_args.class_name)
     create_asset_scripts(Path(parsed_args.path), resource_class, parsed_args.executable)

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -1,0 +1,40 @@
+# (C) Crown Copyright GCHQ
+"""
+Commands for the Concourse Tools CLI.
+"""
+from pathlib import Path
+import textwrap
+
+from concoursetools.cli.parser import CLI
+from concoursetools.colour import Colour, colour_print
+from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile, import_resource_class_from_module
+
+cli = CLI()
+
+
+@cli.register(allow_short={"executable", "class_name", "resource_file"})
+def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
+           class_name: str | None = None, docker: bool = False, include_rsa: bool = False) -> None:
+    """
+    Invoke the legacy CLI.
+
+    :param path: The location at which to place the scripts.
+    :param executable: The python executable to place at the top of the file. Defaults to '/usr/bin/env python3'.
+    :param resource_file: The path to the module containing the resource class. Defaults to 'concourse.py'.
+    :param class_name: The name of the resource class in the module, if there are multiple.
+    :param docker: Pass to create a skeleton Dockerfile at the path instead.
+    :param include_rsa: Enable the Dockerfile to (securely) use your RSA private key during building.
+    """
+    colour_print(textwrap.dedent("""
+    The legacy CLI has been deprecated.
+    Please refer to the documentation or help pages for the up to date CLI.
+    This CLI will be removed in version 0.10.0, or in version 1.0.0, whichever is sooner.
+    """), colour=Colour.RED)
+    parsed_args = Namespace(path=path, executable=executable, resource_file=resource_file, class_name=class_name,
+                            docker=docker, include_rsa=include_rsa)
+    if parsed_args.docker:
+        create_dockerfile(parsed_args)
+        return
+
+    resource_class = import_resource_class_from_module(parsed_args.resource_path, parsed_args.class_name)  # type: ignore[var-annotated]
+    create_asset_scripts(Path(parsed_args.path), resource_class, parsed_args.executable)

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -32,6 +32,24 @@ def assets(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
 
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})
+def dockerfile(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
+               class_name: str | None = None, include_rsa: bool = False) -> None:
+    """
+    Create the Dockerfile.
+
+    :param path: The location to which to write the Dockerfile.
+                 Pass '.' to write it to the current directory.
+    :param executable: The python executable to place at the top of the file. Defaults to '/usr/bin/env python3'.
+    :param resource_file: The path to the module containing the resource class. Defaults to 'concourse.py'.
+    :param class_name: The name of the resource class in the module, if there are multiple.
+    :param include_rsa: Enable the Dockerfile to (securely) use your RSA private key during building.
+    """
+    parsed_args = Namespace(path=path, executable=executable, resource_file=resource_file, class_name=class_name,
+                            docker=True, include_rsa=include_rsa)
+    create_dockerfile(parsed_args)
+
+
+@cli.register(allow_short={"executable", "class_name", "resource_file"})
 def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
            class_name: str | None = None, docker: bool = False, include_rsa: bool = False) -> None:
     """
@@ -49,10 +67,7 @@ def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
     Please refer to the documentation or help pages for the up to date CLI.
     This CLI will be removed in version 0.10.0, or in version 1.0.0, whichever is sooner.
     """), colour=Colour.RED)
-    parsed_args = Namespace(path=path, executable=executable, resource_file=resource_file, class_name=class_name,
-                            docker=docker, include_rsa=include_rsa)
-    if parsed_args.docker:
-        create_dockerfile(parsed_args)
-        return
-
+    if docker:
+        return dockerfile(path, executable=executable, resource_file=resource_file, class_name=class_name,
+                          include_rsa=include_rsa)
     assets(path, executable=executable, resource_file=resource_file, class_name=class_name)

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -15,6 +15,23 @@ cli = CLI()
 
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})
+def assets(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
+           class_name: str | None = None) -> None:
+    """
+    Create the assets script directory.
+
+    :param path: The location at which to the script files will be written.
+                 Pass '.' to write scripts to the current directory.
+    :param executable: The python executable to place at the top of the file. Defaults to '/usr/bin/env python3'.
+    :param resource_file: The path to the module containing the resource class. Defaults to 'concourse.py'.
+    :param class_name: The name of the resource class in the module, if there are multiple.
+    """
+    resource_class = import_single_class_from_module(Path(resource_file), parent_class=ConcourseResource,  # type: ignore[type-abstract]
+                                                     class_name=class_name)
+    create_asset_scripts(Path(path), resource_class, executable)
+
+
+@cli.register(allow_short={"executable", "class_name", "resource_file"})
 def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
            class_name: str | None = None, docker: bool = False, include_rsa: bool = False) -> None:
     """
@@ -38,6 +55,4 @@ def legacy(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
         create_dockerfile(parsed_args)
         return
 
-    resource_class = import_single_class_from_module(parsed_args.resource_path, parent_class=ConcourseResource,  # type: ignore[type-abstract]
-                                                     class_name=parsed_args.class_name)
-    create_asset_scripts(Path(parsed_args.path), resource_class, parsed_args.executable)
+    assets(path, executable=executable, resource_file=resource_file, class_name=class_name)

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -3,15 +3,18 @@
 Commands for the Concourse Tools CLI.
 """
 from pathlib import Path
+import sys
 import textwrap
 
 from concoursetools.cli.parser import CLI
 from concoursetools.colour import Colour, colour_print
-from concoursetools.dockertools import MethodName, Namespace, ScriptName, create_dockerfile, create_script_file
+from concoursetools.dockertools import MethodName, ScriptName, create_script_file
 from concoursetools.importing import import_single_class_from_module
 from concoursetools.resource import ConcourseResource
 
 cli = CLI()
+
+DEFAULT_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})
@@ -43,7 +46,8 @@ def assets(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})
 def dockerfile(path: str, /, *, executable: str = "/usr/bin/env python3", resource_file: str = "concourse.py",
-               class_name: str | None = None, include_rsa: bool = False) -> None:
+               class_name: str | None = None, include_rsa: bool = False, encoding: str | None = None,
+               dev: bool = False) -> None:
     """
     Create the Dockerfile.
 
@@ -53,10 +57,84 @@ def dockerfile(path: str, /, *, executable: str = "/usr/bin/env python3", resour
     :param resource_file: The path to the module containing the resource class. Defaults to 'concourse.py'.
     :param class_name: The name of the resource class in the module, if there are multiple.
     :param include_rsa: Enable the Dockerfile to (securely) use your RSA private key during building.
+    :param encoding: The encoding of the created file. If not passed, Concourse Tools will use the user's default encoding.
+    :param dev: Pass to copy a local version of Concourse Tools to the image, instead of installing from PyPI.
+                The onus is on the user to ensure that the "concoursetools" exists in the working directory at
+                Docker build time.
     """
-    parsed_args = Namespace(path=path, executable=executable, resource_file=resource_file, class_name=class_name,
-                            docker=True, include_rsa=include_rsa)
-    create_dockerfile(parsed_args)
+    directory_path = Path(path)
+    if directory_path.is_dir():
+        file_path = directory_path / "Dockerfile"
+    else:
+        file_path = directory_path
+
+    cli_split_command = ["python3", "-m", "concoursetools", "assets", ".", "-r", resource_file]
+    if class_name is not None:
+        cli_split_command.extend(["-c", class_name])
+
+    cli_command = " ".join(cli_split_command)
+
+    if dev is False:
+        pip_install_command = """
+        RUN python3 -m pip install --upgrade pip && \\
+            pip install -r requirements.txt --no-deps
+        """.strip()
+    else:
+        pip_install_command = """
+        COPY concoursetools concoursetools
+
+        RUN python3 -m pip install --upgrade pip && \\
+            pip install ./concoursetools && \\
+            pip install -r requirements.txt --no-deps
+        """.strip()
+
+    if include_rsa:
+        contents = textwrap.dedent(f"""
+        FROM python:{DEFAULT_PYTHON_VERSION}-alpine as builder
+
+        ARG ssh_known_hosts
+        ARG ssh_private_key
+
+        RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
+        RUN echo "$ssh_known_hosts" > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+        RUN echo "$ssh_private_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
+
+        COPY requirements.txt requirements.txt
+
+        RUN python3 -m venv /opt/venv
+        # Activate venv
+        ENV PATH="/opt/venv/bin:$PATH"
+
+        {pip_install_command}
+
+
+        FROM python:{DEFAULT_PYTHON_VERSION}-alpine as runner
+        COPY --from=builder /opt/venv /opt/venv
+        # Activate venv
+        ENV PATH="/opt/venv/bin:$PATH"
+
+        WORKDIR /opt/resource/
+        COPY {resource_file} ./{resource_file}
+        RUN {cli_command}
+
+        ENTRYPOINT ["python3"]
+        """).lstrip()
+    else:
+        contents = textwrap.dedent(f"""
+        FROM python:{DEFAULT_PYTHON_VERSION}-alpine
+
+        COPY requirements.txt requirements.txt
+
+        {pip_install_command}
+
+        WORKDIR /opt/resource/
+        COPY {resource_file} ./{resource_file}
+        RUN {cli_command}
+
+        ENTRYPOINT ["python3"]
+        """).lstrip()
+
+    file_path.write_text(contents, encoding=encoding)
 
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})

--- a/concoursetools/cli/commands.py
+++ b/concoursetools/cli/commands.py
@@ -7,7 +7,7 @@ import textwrap
 
 from concoursetools.cli.parser import CLI
 from concoursetools.colour import Colour, colour_print
-from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile
+from concoursetools.dockertools import MethodName, Namespace, ScriptName, create_dockerfile, create_script_file
 from concoursetools.importing import import_single_class_from_module
 from concoursetools.resource import ConcourseResource
 
@@ -28,7 +28,17 @@ def assets(path: str, /, *, executable: str = "/usr/bin/env python3", resource_f
     """
     resource_class = import_single_class_from_module(Path(resource_file), parent_class=ConcourseResource,  # type: ignore[type-abstract]
                                                      class_name=class_name)
-    create_asset_scripts(Path(path), resource_class, executable)
+    assets_folder = Path(path)
+    assets_folder.mkdir(parents=True, exist_ok=True)
+
+    file_name_to_method_name: dict[ScriptName, MethodName] = {
+        "check": "check_main",
+        "in": "in_main",
+        "out": "out_main",
+    }
+    for file_name, method_name in file_name_to_method_name.items():
+        file_path = assets_folder / file_name
+        create_script_file(file_path, resource_class, method_name, executable)
 
 
 @cli.register(allow_short={"executable", "class_name", "resource_file"})

--- a/concoursetools/cli/docstring.py
+++ b/concoursetools/cli/docstring.py
@@ -1,0 +1,81 @@
+# (C) Crown Copyright GCHQ
+"""
+Concourse Tools uses a custom CLI tool for easier management of command line functions.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+import inspect
+import re
+from typing import TypeVar
+
+RE_PARAM = re.compile(r":param (.*?):")
+RE_WHITESPACE = re.compile(r"\s+")
+
+CLIFunction = Callable[..., None]
+CLIFunctionT = TypeVar("CLIFunctionT", bound=CLIFunction)
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class Docstring:
+    """
+    Represents a function docstring.
+
+    :param first_line: The first line of the docstring (separated by double whitespace).
+    :param description: The remaining description before any parameters.
+    :param parameters: A mapping of parameter name to description, with newlines replaced with whitespace.
+    """
+    first_line: str
+    description: str
+    parameters: dict[str, str]
+
+    @classmethod
+    def from_object(cls, obj: object) -> "Docstring":
+        """
+        Parse an object with a docstring.
+
+        :param obj: An object which may have a docstring, such as a function or module.
+        """
+        raw_docstring = inspect.getdoc(obj) or ""
+        return cls.from_string(raw_docstring)
+
+    @classmethod
+    def from_string(cls, raw_docstring: str) -> "Docstring":
+        """
+        Parse a docstring.
+
+        :param raw_docstring: The raw docstring of an object.
+        """
+        try:
+            first_line, remaining_lines = raw_docstring.split("\n\n", maxsplit=1)
+        except ValueError:
+            if RE_PARAM.match(raw_docstring.strip()):  # all we have are params with no description
+                first_line = ""
+                remaining_lines = raw_docstring.strip()
+            else:
+                first_line = raw_docstring.strip()
+                return cls(first_line, "", {})
+
+        description, *remaining_params = RE_PARAM.split(remaining_lines.lstrip())
+        parameters = {param: " ".join(info.split()).strip() for param, info in _pair_up(remaining_params)}
+        return cls(first_line, description.strip(), parameters)
+
+
+def _pair_up(data: list[str]) -> Generator[tuple[str, str], None, None]:
+    """
+    Pair up a list of items.
+
+    :param data: A list to be paired.
+    :raises ValueError: If there are an odd number of values in the list.
+
+    :Example:
+        >>> list(_pair_up([1, 2, 3, 4, 5, 6]))
+        [(1, 2), (3, 4), (5, 6)]
+    """
+    for i in range(0, len(data), 2):
+        try:
+            yield data[i], data[i+1]
+        except IndexError:
+            raise ValueError(f"Needed an even number of values, got {len(data)}")

--- a/concoursetools/cli/parser.py
+++ b/concoursetools/cli/parser.py
@@ -1,0 +1,454 @@
+# (C) Crown Copyright GCHQ
+"""
+Concourse Tools uses a custom CLI tool for easier management of command line functions.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from argparse import ArgumentParser
+from collections.abc import Callable, Generator
+from dataclasses import dataclass
+import inspect
+import shutil
+import textwrap
+from typing import Any, Generic, TypeVar
+
+from concoursetools import __version__
+from concoursetools.cli.docstring import Docstring
+
+CLIFunction = Callable[..., None]
+CLIFunctionT = TypeVar("CLIFunctionT", bound=CLIFunction)
+T = TypeVar("T")
+
+
+class _CLIParser(ABC):
+
+    @abstractmethod
+    def invoke(self, args: list[str]) -> None:
+        """
+        Invoke the CLI.
+
+        :param args: Arguments to be parsed.
+        """
+        ...
+
+    def print_help_page(self, usage_string: str, help_sections: dict[str, dict[str, str | None]], spacing: int = 2,
+                        separation: int = 1) -> None:
+        max_key_width = max(self._max_key_length(d) for _, d in help_sections.items())
+
+        self.print_help_section("Usage", {usage_string: None}, key_width=max_key_width, spacing=spacing)
+
+        separator = "\n" * separation
+        print(separator, end="")
+
+        for title, options in help_sections.items():
+            self.print_help_section(title, options, key_width=max_key_width, spacing=spacing)
+            print(separator, end="")
+
+    def print_help_section(self, title: str, options: dict[str, str | None], spacing: int = 2,
+                           key_width: int | None = None, sort_keys: bool = False) -> None:
+        """
+        Print a section in the help page.
+
+        :param title: The title of the section.
+        :param options: Keys and values for the options.
+        :param spacing: The size of the indent for the keys and values, as well as the minimum spacing between keys and values.
+        :param key_width: The width of the key column. If set to :obj:`None`, the width will be determined as the maximum length of all of the keys.
+        :param sort_keys: Set to :obj:`True` to sort the keys before printing. Otherwise they are printed in dictionary order.
+        """
+        print(f"{title}:")
+        margin = " " * spacing
+        if key_width is None:
+            key_width = self._max_key_length(options)
+
+        if sort_keys:
+            items = sorted(options.items())
+        else:
+            items = list(options.items())
+
+        total_indent_length = (spacing + key_width + spacing)
+        max_width, _ = shutil.get_terminal_size()
+        wrapper = textwrap.TextWrapper(width=max_width, subsequent_indent=" " * total_indent_length)
+
+        usage_suffix = " \\"
+        usage_wrapper = textwrap.TextWrapper(width=max_width - len(usage_suffix), subsequent_indent=" " * (spacing + 2))
+
+        for key, value in items:
+            if value is None:  # this is for the usage string
+                unwrapped_line = margin + key.ljust(key_width)
+                *lines, final_line = usage_wrapper.wrap(unwrapped_line)
+                for line in lines:
+                    print(line + usage_suffix)
+                print(final_line)
+            else:
+                unwrapped_line = margin + key.ljust(key_width) + margin + value
+                for line in wrapper.wrap(unwrapped_line):
+                    print(line)
+
+    @staticmethod
+    def _max_key_length(d: dict[str, Any]) -> int:
+        return max((len(key) for key in d), default=0)
+
+
+class CLI(_CLIParser):
+    """
+    Represents a command line interface.
+    """
+    def __init__(self) -> None:
+        self.commands: dict[str, CLICommand] = {}
+
+    def invoke(self, args: list[str]) -> None:
+        """
+        Invoke the CLI.
+
+        :param args: Arguments to be parsed.
+        """
+        try:
+            command_name, *remaining_args = args
+        except ValueError:
+            if args:
+                raise
+            return self.print_help()
+        try:
+            command = self.commands[command_name]
+        except KeyError:
+            if command_name in set(HELP_OPTION.aliases):
+                return self.print_help()
+            elif command_name in set(VERSION_OPTION.aliases):
+                return self.print_version()
+            return self.invoke(["legacy"] + args)
+        command.invoke(remaining_args)
+
+    def register(self, allow_short: set[str] | None = None) -> Callable[[CLIFunctionT], CLIFunctionT]:
+        """
+        Decorate a function.
+
+        The decorated function will be registered as a command. Positional-only parameters will become arguments
+        and keyword-only parameters will become options. All parameters must be one or the other.
+
+        :param allow_short: A set of function parameters that are allowed a one-letter alias. By default,
+                            the parameter ``my_parameter`` becomes ``--my-parameter``, but by including
+                            ``my_parameter`` in this set, ``-m`` will also be valid on the command line.
+        """
+        def decorator(func: CLIFunctionT) -> CLIFunctionT:
+            self.register_function(func, allow_short=allow_short)
+            return func
+        return decorator
+
+    def register_function(self, func: CLIFunction, allow_short: set[str] | None = None) -> None:
+        """
+        Manually register a function.
+
+        :param func: A function to be registered as a command. Positional-only parameters will become arguments
+                     and keyword-only parameters will become options. All parameters must be one or the other.
+        :param allow_short: A set of function parameters that are allowed a one-letter alias. By default,
+                            the parameter ``my_parameter`` becomes ``--my-parameter``, but by including
+                            ``my_parameter`` in this set, ``-m`` will also be valid on the command line.
+        """
+        if allow_short is None:
+            allow_short = set()
+
+        cli_command = CLICommand.from_function(func, allow_short)
+        self.commands[cli_command.name] = cli_command
+
+    def print_help(self, spacing: int = 2, separation: int = 1) -> None:
+        """
+        Print the help page.
+
+        :param spacing: The size of the indent for the keys and values, as well as the minimum spacing
+                        between keys and values.
+        :param separation: The number of new lines between help sections.
+        """
+        usage_string = "python3 -m concoursetools <command> [OPTIONS]"
+
+        global_options: dict[str, str | None] = {
+            "-h, --help": "Show this help message",
+            "-v, --version": "Show the Concourse Tools version",
+        }
+
+        major_sections = {
+            "Global Options": global_options,
+            "Available Commands": {command_name: self.commands[command_name].description
+                                   for command_name in sorted(self.commands)}
+        }
+
+        self.print_help_page(usage_string, major_sections, spacing=spacing, separation=separation)
+
+    def print_version(self) -> None:
+        """Print the version of Concourse Tools."""
+        print(f"Concourse Tools v{__version__}")
+
+
+class CLICommand(_CLIParser):
+    """
+    Represents a command in a CLI.
+
+    :param name: The name of the command.
+    :param description: An optional description of the command.
+    :param inner_function: The function on which the command is based.
+    :param inner_parser: Used to parse the arguments for the command.
+    :param positional_arguments: A list of positional arguments.
+    :param options: A list of options.
+    """
+    def __init__(self, name: str, description: str | None, inner_function: CLIFunction, inner_parser: ArgumentParser,
+                 positional_arguments: list[PositionalArgument[Any]], options: list[Option[Any]]) -> None:
+        self.name = name
+        self.description = description
+        self.inner_function = inner_function
+        self.inner_parser = inner_parser
+        self.positional_arguments = positional_arguments
+        self.options = options
+
+    def invoke(self, args: list[str]) -> None:
+        """
+        Invoke the CLI.
+
+        :param args: Arguments to be parsed.
+        """
+        if set(HELP_OPTION.aliases) & set(args):
+            return self.print_help()
+
+        args, kwargs = self.parse_args(args)
+        self.inner_function(*args, **kwargs)
+
+    def parse_args(self, args: list[str]) -> tuple[list[Any], dict[str, Any]]:
+        """
+        Parse the arguments for a function.
+
+        :param args: Arguments to be parsed.
+        :returns: The args and kwargs to be passed to the inner function.
+        """
+        parsed_args_namespace = self.inner_parser.parse_args(args)
+        kwargs = dict(parsed_args_namespace._get_kwargs())
+        args = []
+        for param_name, parameter in inspect.signature(self.inner_function).parameters.items():
+            if parameter.kind is inspect._ParameterKind.POSITIONAL_ONLY:
+                value = kwargs.pop(param_name)
+                args.append(value)
+        return args, kwargs
+
+    def print_help(self, spacing: int = 2, separation: int = 1) -> None:
+        """
+        Print the help page for the command.
+
+        :param spacing: The size of the indent for the keys and values, as well as the minimum spacing
+                        between keys and values.
+        :param separation: The number of new lines between help sections.
+        """
+        global_options: dict[str, str | None] = {
+            "-h, --help": "Show this help message",
+        }
+
+        command_arguments: dict[str, str | None] = {parameter.name: parameter.description or "" for parameter in self.positional_arguments}
+        command_options: dict[str, str | None] = {", ".join(parameter.aliases): parameter.description for parameter in self.options}
+
+        major_sections = {
+            "Global Options": global_options,
+            "Command Arguments (required)": command_arguments,
+            "Command Options": command_options,
+        }
+
+        self.print_help_page(major_sections, spacing=spacing, separation=separation)
+
+    def print_help_page(self, help_sections: dict[str, dict[str, str | None]], spacing: int = 2,
+                        separation: int = 1) -> None:
+
+        self.print_help_section("Usage", {self.usage_string(): None}, spacing=spacing)
+
+        separator = "\n" * separation
+        print(separator, end="")
+
+        max_key_width = max(self._max_key_length(d) for _, d in help_sections.items())
+
+        for title, options in help_sections.items():
+            self.print_help_section(title, options, key_width=max_key_width, spacing=spacing)
+            print(separator, end="")
+
+    def usage_string(self) -> str:
+        """Return the usage string for the command."""
+        usage_components = ["python3 -m concoursetools", self.name]
+        for parameter in self.positional_arguments:
+            usage_components.append(f"<{parameter.name}>")
+
+        usage_components.append("[OPTIONS]")
+        return " ".join(usage_components)
+
+    @classmethod
+    def from_function(cls, func: CLIFunction, allow_short: set[str] | None = None) -> CLICommand:
+        """
+        Create a new parser from a function.
+
+        :param func: A function to be registered as a command. Positional-only parameters will become arguments
+                     and keyword-only parameters will become options. All parameters must be one or the other.
+        :param allow_short: A set of function parameters that are allowed a one-letter alias. By default,
+                            the parameter ``my_parameter`` becomes ``--my-parameter``, but by including
+                            ``my_parameter`` in this set, ``-m`` will also be valid on the command line.
+        """
+        if allow_short is None:
+            allow_short = set()
+
+        docstring = Docstring.from_object(func)
+
+        parser = ArgumentParser(f"python3 -m concoursetools {func.__name__}", description=docstring.first_line)
+        positional_arguments: list[PositionalArgument[Any]] = []
+        options: list[Option[Any]] = []
+
+        for parameter in Parameter.yield_from_function(func, allow_short):
+            parameter.add_to_parser(parser)
+            if isinstance(parameter, Option):
+                options.append(parameter)
+            elif isinstance(parameter, PositionalArgument):
+                positional_arguments.append(parameter)
+            else:
+                raise TypeError
+
+        return cls(func.__name__, docstring.first_line, func, parser, positional_arguments, options)
+
+
+@dataclass
+class Parameter(ABC, Generic[T]):
+    """
+    Represents a generic function/CLI parameter.
+
+    :param name: The name of the parameter.
+    :param param_type: The Python type of the parameter.
+    :param description: An optional description of the parameter.
+    """
+    name: str
+    param_type: type[T]
+    description: str | None = None
+
+    @property
+    def long_alias(self) -> str:
+        """
+        The long alias for the parameter.
+
+        :Example:
+            >>> Option("my_option", str).long_alias
+            '--my-option'
+        """
+        return f"--{self.name}".replace("_", "-")
+
+    @property
+    def short_alias(self) -> str:
+        """
+        The short alias for the parameter.
+
+        :Example:
+            >>> Option("my_option", str).short_alias
+            '-m'
+        """
+        return f"-{self.name[0]}"
+
+    @property
+    @abstractmethod
+    def aliases(self) -> tuple[str, ...]:
+        """The aliases for the option."""
+        ...
+
+    @abstractmethod
+    def add_to_parser(self, parser: ArgumentParser) -> None:
+        """
+        Add the parameter to a parser.
+
+        :param parser: The parser in question.
+        :seealso: This is done using :meth:`argparse.ArgumentParser.add_argument`.
+        """
+        ...
+
+    @classmethod
+    def yield_from_function(cls, func: CLIFunction, allow_short: set[str]) -> Generator[Parameter[Any], None, None]:
+        """
+        Yield parameters from a function.
+
+        Parameters are parsed from the docstring using a combination of :func:`inspect.signature`
+        and :meth:`concoursetools.cli.docstring.Docstring.from_object`.
+
+        :param func: The function to parse.
+        :param allow_short: A set of function parameters that are allowed a one-letter alias. By default,
+                            the parameter ``my_parameter`` becomes ``--my-parameter``, but by including
+                            ``my_parameter`` in this set, ``-m`` will also be valid on the command line.
+        """
+        docstring = Docstring.from_object(func)
+
+        for parameter_name, parameter in inspect.signature(func).parameters.items():
+            parameter_type = parameter.annotation
+            parameter_help = docstring.parameters.get(parameter_name)
+
+            from types import UnionType
+            if issubclass(type(parameter_type), UnionType):  # isinstance won't work here
+                parameter_type, other_type = getattr(parameter_type, "__args__")
+                if not issubclass(other_type, type(None)):  # 'other_type is None' won't work here'
+                    raise RuntimeError(f"Could not handle type: {parameter.annotation!r}")
+
+            if parameter.kind is inspect._ParameterKind.POSITIONAL_ONLY:
+                yield PositionalArgument(parameter_name, parameter_type, parameter_help)
+            elif parameter.kind is inspect._ParameterKind.KEYWORD_ONLY:
+                if issubclass(parameter_type, bool):
+                    yield FlagOption(parameter_name, parameter_help, parameter.default)
+                else:
+                    yield Option(parameter_name, parameter_type, parameter_help, parameter.default,
+                                 allow_short=(parameter_name in allow_short))
+            else:
+                raise ValueError("Parameters must be positional or keyword only.")
+
+
+@dataclass
+class PositionalArgument(Parameter[T]):
+    """
+    Represents a positional function/CLI parameter.
+
+    :param name: The name of the argument.
+    :param param_type: The Python type of the argument.
+    :param description: An optional description of the argument.
+    """
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        """The aliases for the option."""
+        return (self.name,)
+
+    def add_to_parser(self, parser: ArgumentParser) -> None:
+        parser.add_argument(*self.aliases, type=self.param_type, help=self.description)
+
+
+@dataclass
+class Option(Parameter[T]):
+    """
+    Represents a generic function/CLI option.
+
+    :param name: The name of the option.
+    :param param_type: The Python type of the option.
+    :param description: An optional description of the option.
+    :param default: The option default, if set.
+    :param allow_short: Set to :obj:`True` to allow a short option, i.e. ``-o`` as well as ``--option``.
+    """
+    default: T | None = None
+    allow_short: bool = False
+
+    @property
+    def aliases(self) -> tuple[str, ...]:
+        if self.allow_short:
+            return (self.short_alias, self.long_alias)
+        return (self.long_alias,)
+
+    def add_to_parser(self, parser: ArgumentParser) -> None:
+        parser.add_argument(*self.aliases, type=self.param_type, default=self.default, help=self.description)
+
+
+class FlagOption(Option[bool]):
+    """
+    Represents a generic function/CLI flag.
+
+    :param name: The name of the flag.
+    :param description: An optional description of the flag.
+    :param default: The option default, if set. Should be either :obj:`True` or :obj:`False`.
+    """
+    def __init__(self, name: str, description: str | None, default: bool):
+        super().__init__(name, bool, description, default, allow_short=False)
+
+    def add_to_parser(self, parser: ArgumentParser) -> None:
+        parser.add_argument(*self.aliases, action="store_true", help=self.description)
+
+
+HELP_OPTION = Option("help", bool, "", allow_short=True)
+VERSION_OPTION = Option("version", bool, "", allow_short=True)

--- a/concoursetools/cli/parser.py
+++ b/concoursetools/cli/parser.py
@@ -53,8 +53,8 @@ class _CLIParser(ABC):
         :param title: The title of the section.
         :param options: Keys and values for the options.
         :param spacing: The size of the indent for the keys and values, as well as the minimum spacing between keys and values.
-        :param key_width: The width of the key column. If set to :obj:`None`, the width will be determined as the maximum length of all of the keys.
-        :param sort_keys: Set to :obj:`True` to sort the keys before printing. Otherwise they are printed in dictionary order.
+        :param key_width: The width of the key column. If set to :data:`None`, the width will be determined as the maximum length of all of the keys.
+        :param sort_keys: Set to :data:`True` to sort the keys before printing. Otherwise they are printed in dictionary order.
         """
         print(f"{title}:")
         margin = " " * spacing
@@ -420,7 +420,7 @@ class Option(Parameter[T]):
     :param param_type: The Python type of the option.
     :param description: An optional description of the option.
     :param default: The option default, if set.
-    :param allow_short: Set to :obj:`True` to allow a short option, i.e. ``-o`` as well as ``--option``.
+    :param allow_short: Set to :data:`True` to allow a short option, i.e. ``-o`` as well as ``--option``.
     """
     default: T | None = None
     allow_short: bool = False
@@ -441,7 +441,7 @@ class FlagOption(Option[bool]):
 
     :param name: The name of the flag.
     :param description: An optional description of the flag.
-    :param default: The option default, if set. Should be either :obj:`True` or :obj:`False`.
+    :param default: The option default, if set. Should be either :data:`True` or :data:`False`.
     """
     def __init__(self, name: str, description: str | None, default: bool):
         super().__init__(name, bool, description, default, allow_short=False)

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -40,7 +40,7 @@ def create_dockerfile(args: "Namespace", encoding: str | None = None,
     else:
         file_path = directory_path
 
-    cli_split_command = ["python3", "-m", "concoursetools", ".", "-r", args.resource_file]
+    cli_split_command = ["python3", "-m", "concoursetools", "assets", ".", "-r", args.resource_file]
     if args.class_name is not None:
         cli_split_command.extend(["-c", args.class_name])
 

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -4,19 +4,19 @@ Functions for creating the Dockerfile or asset files.
 """
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 import inspect
 from pathlib import Path
 import sys
 import textwrap
 from types import MethodType
-from typing import TypeVar, cast
+from typing import Any, Literal, TypeVar
 
 from concoursetools import ConcourseResource
-from concoursetools.typing import VersionProtocol
 
 T = TypeVar("T")
+ScriptName = Literal["check", "in", "out"]
+MethodName = Literal["check_main", "in_main", "out_main"]
 
 DEFAULT_EXECUTABLE = "/usr/bin/env python3"
 DEFAULT_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -109,47 +109,23 @@ def create_dockerfile(args: "Namespace", encoding: str | None = None,
     file_path.write_text(contents, encoding=encoding)
 
 
-def create_asset_scripts(assets_folder: Path, resource_class: type[ConcourseResource],  # type: ignore[type-arg]
-                         executable: str = DEFAULT_EXECUTABLE) -> None:
-    """
-    Create the scripts in a given folder.
-
-    :param assets_folder: The location to which the assets folder will be written.
-                          The folder will be created if it doesn't yet exist.
-    :param resource_class: A :class:`~concoursetools.resource.ConcourseResource` subclass
-                           whose methods will be passed to :func:`create_script_file`.
-    :param executable: The executable to use for the script (at the top).
-    """
-    assets_folder.mkdir(parents=True, exist_ok=True)
-
-    file_to_method: dict[str, Callable[[], None]] = {
-        "check": resource_class.check_main,
-        "in": resource_class.in_main,
-        "out": resource_class.out_main,
-    }
-    for file_name, method in file_to_method.items():
-        file_path = assets_folder / file_name
-        create_script_file(file_path, method, executable)
-
-
-def create_script_file(path: Path, method: Callable[[], None], executable: str = DEFAULT_EXECUTABLE,
-                       permissions: int = 0o755, encoding: str | None = None) -> None:
+def create_script_file(path: Path, resource_class: type[ConcourseResource[Any]], method_name: MethodName,
+                       executable: str = DEFAULT_EXECUTABLE, permissions: int = 0o755,
+                       encoding: str | None = None) -> None:
     """
     Create a script file at a given path.
 
     :param path: The path at which the file will be created.
-    :param method: The method of the :class:`~concoursetools.resource.ConcourseResource` to be exported.
+    :param resource_class: The :class:`~concoursetools.resource.ConcourseResource` class to be exported.
+    :param method_name: The name of the method to be invoked.
     :param executable: The executable to use for the script (at the top).
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
     :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
                      Setting to :data:`None` (default) will use the user's default encoding.
     """
+    method: MethodType = getattr(resource_class, method_name)
     docstring = inspect.getdoc(method) or ""
     docstring_header, *_ = docstring.split("\n")
-
-    method = cast(MethodType, method)
-    resource_class = cast(type[ConcourseResource[VersionProtocol]], method.__self__)
-    method_name = method.__name__
 
     contents = textwrap.dedent(f"""
     #!{executable}

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -29,8 +29,8 @@ def create_dockerfile(args: "Namespace", encoding: str | None = None,
 
     :param args: The CLI args.
     :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
-                     Setting to :obj:`None` (default) will use the user's default encoding.
-    :param concoursetools_path: A path to a local copy of concoursetools. If not set to :obj:`None`, this directory
+                     Setting to :data:`None` (default) will use the user's default encoding.
+    :param concoursetools_path: A path to a local copy of concoursetools. If not set to :data:`None`, this directory
                                 will be copied over an installed before any requirements. Path should be relative to
                                 the current directory.
     """
@@ -142,7 +142,7 @@ def create_script_file(path: Path, method: Callable[[], None], executable: str =
     :param executable: The executable to use for the script (at the top).
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
     :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
-                     Setting to :obj:`None` (default) will use the user's default encoding.
+                     Setting to :data:`None` (default) will use the user's default encoding.
     """
     docstring = inspect.getdoc(method) or ""
     docstring_header, *_ = docstring.split("\n")

--- a/concoursetools/dockertools.py
+++ b/concoursetools/dockertools.py
@@ -4,7 +4,6 @@ Functions for creating the Dockerfile or asset files.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
 import inspect
 from pathlib import Path
 import sys
@@ -20,93 +19,6 @@ MethodName = Literal["check_main", "in_main", "out_main"]
 
 DEFAULT_EXECUTABLE = "/usr/bin/env python3"
 DEFAULT_PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
-
-
-def create_dockerfile(args: "Namespace", encoding: str | None = None,
-                      concoursetools_path: Path | None = None) -> None:
-    """
-    Create a skeleton dockerfile.
-
-    :param args: The CLI args.
-    :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
-                     Setting to :data:`None` (default) will use the user's default encoding.
-    :param concoursetools_path: A path to a local copy of concoursetools. If not set to :data:`None`, this directory
-                                will be copied over an installed before any requirements. Path should be relative to
-                                the current directory.
-    """
-    directory_path = Path(args.path)
-    if directory_path.is_dir():
-        file_path = directory_path / "Dockerfile"
-    else:
-        file_path = directory_path
-
-    cli_split_command = ["python3", "-m", "concoursetools", "assets", ".", "-r", args.resource_file]
-    if args.class_name is not None:
-        cli_split_command.extend(["-c", args.class_name])
-
-    cli_command = " ".join(cli_split_command)
-
-    if concoursetools_path is None:
-        pip_install_command = """
-        RUN python3 -m pip install --upgrade pip && \\
-            pip install -r requirements.txt --no-deps
-        """.strip()
-    else:
-        pip_install_command = f"""
-        COPY {str(concoursetools_path)} concoursetools
-
-        RUN python3 -m pip install --upgrade pip && \\
-            pip install ./concoursetools && \\
-            pip install -r requirements.txt --no-deps
-        """.strip()
-
-    if args.include_rsa:
-        contents = textwrap.dedent(f"""
-        FROM python:{DEFAULT_PYTHON_VERSION}-alpine as builder
-
-        ARG ssh_known_hosts
-        ARG ssh_private_key
-
-        RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh
-        RUN echo "$ssh_known_hosts" > /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
-        RUN echo "$ssh_private_key" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa
-
-        COPY requirements.txt requirements.txt
-
-        RUN python3 -m venv /opt/venv
-        # Activate venv
-        ENV PATH="/opt/venv/bin:$PATH"
-
-        {pip_install_command}
-
-
-        FROM python:{DEFAULT_PYTHON_VERSION}-alpine as runner
-        COPY --from=builder /opt/venv /opt/venv
-        # Activate venv
-        ENV PATH="/opt/venv/bin:$PATH"
-
-        WORKDIR /opt/resource/
-        COPY {args.resource_file} ./{args.resource_file}
-        RUN {cli_command}
-
-        ENTRYPOINT ["python3"]
-        """).lstrip()
-    else:
-        contents = textwrap.dedent(f"""
-        FROM python:{DEFAULT_PYTHON_VERSION}-alpine
-
-        COPY requirements.txt requirements.txt
-
-        {pip_install_command}
-
-        WORKDIR /opt/resource/
-        COPY {args.resource_file} ./{args.resource_file}
-        RUN {cli_command}
-
-        ENTRYPOINT ["python3"]
-        """).lstrip()
-
-    file_path.write_text(contents, encoding=encoding)
 
 
 def create_script_file(path: Path, resource_class: type[ConcourseResource[Any]], method_name: MethodName,
@@ -141,28 +53,3 @@ def create_script_file(path: Path, resource_class: type[ConcourseResource[Any]],
 
     path.write_text(contents, encoding=encoding)
     path.chmod(permissions)
-
-
-@dataclass
-class Namespace:
-    """
-    Represents the parsed args for typing purposes.
-
-    :param path: The location at which to place the scripts.
-    :param executable: The python executable to place at the top of the file.
-    :param resource_file: The path to the module containing the resource class.
-    :param class_name: The name of the resource class in the module, if there are multiple.
-    :param docker: Pass to create a skeleton Dockerfile at the path instead.
-    :param include_rsa: Enable the Dockerfile to (securely) use your RSA private key during building.
-    """
-    path: str
-    executable: str = DEFAULT_EXECUTABLE
-    resource_file: str = "concourse.py"
-    class_name: str | None = None
-    docker: bool = False
-    include_rsa: bool = False
-
-    @property
-    def resource_path(self) -> Path:
-        """Return a path object pointing to the resource file."""
-        return Path(self.resource_file)

--- a/concoursetools/importing.py
+++ b/concoursetools/importing.py
@@ -1,0 +1,143 @@
+# (C) Crown Copyright GCHQ
+"""
+Functions for dynamically importing from Python modules.
+"""
+from __future__ import annotations
+
+from collections.abc import Generator, Sequence
+from contextlib import contextmanager
+import importlib.util
+import inspect
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def import_single_class_from_module(file_path: Path, parent_class: type[T], class_name: str | None = None) -> type[T]:
+    """
+    Import the resource class from the module.
+
+    Similar to :func:`import_classes_from_module`, but ensures only one class is returned.
+
+    :param file_path: The location of the module as a file path.
+    :param class_name: The name of the class to extract. Required if multiple are returned.
+    :param parent_class: All subclasses of this class defined within the module
+                         (not imported from elsewhere) will be extracted.
+    :returns: The extracted class.
+    :raises RuntimeError: If too many or too few classes are available in the module, unless the class name is specified.
+    """
+    possible_resource_classes = import_classes_from_module(file_path, parent_class=parent_class)
+
+    if class_name is None:
+        if len(possible_resource_classes) == 1:
+            _, resource_class = possible_resource_classes.popitem()
+        else:
+            if len(possible_resource_classes) == 0:
+                raise RuntimeError(f"No subclasses of {parent_class.__name__!r} found in {file_path}")
+            raise RuntimeError(f"Multiple subclasses of {parent_class.__name__!r} found in {file_path}:"
+                               f" {set(possible_resource_classes)}")
+    else:
+        resource_class = possible_resource_classes[class_name]
+
+    return resource_class
+
+
+def import_classes_from_module(file_path: Path, parent_class: type[T]) -> dict[str, type[T]]:
+    """
+    Import all available resource classes from the module.
+
+    :param file_path: The location of the module as a file path.
+    :param parent_class: All subclasses of this class defined within the module
+                         (not imported from elsewhere) will be extracted.
+    :returns: A mapping of class name to class.
+    """
+    import_path = file_path_to_import_path(file_path)
+    module = import_py_file(import_path, file_path)
+
+    possible_resource_classes = {}
+    for _, cls in inspect.getmembers(module, predicate=inspect.isclass):
+        try:
+            class_is_subclass_of_parent = issubclass(cls, parent_class)
+        except TypeError:
+            class_is_subclass_of_parent = False
+
+        class_is_defined_in_this_module = (cls.__module__ == import_path)
+        class_is_not_private = (not cls.__name__.startswith("_"))
+
+        if class_is_subclass_of_parent and class_is_defined_in_this_module and class_is_not_private:
+            possible_resource_classes[cls.__name__] = cls
+
+    return possible_resource_classes
+
+
+def file_path_to_import_path(file_path: Path) -> str:
+    """
+    Convert a file path to an import path.
+
+    :param file_path: The path to a Python file.
+    :raises ValueError: If the path doesn't end in a '.py' extension.
+
+    :Example:
+        >>> file_path_to_import_path(Path("module.py"))
+        'module'
+        >>> file_path_to_import_path(Path("path/to/module.py"))
+        'path.to.module'
+    """
+    *path_components, file_name = file_path.parts
+    module_name, extension = file_name.split(".")
+    if extension != "py":
+        raise ValueError(f"{file_path!r} does not appear to be a valid Python module")
+
+    path_components.append(module_name)
+    import_path = ".".join(path_components)
+    return import_path
+
+
+def import_py_file(import_path: str, file_path: Path) -> ModuleType:
+    """
+    Import a .py file as a module.
+
+    This is done using a :ref:`standard Python recipe <python3:importlib-examples>` via :mod:`importlib.util`.
+
+    :param import_path: The import path added to :data:`sys.modules`.
+    :param file_path: The path to the .py module.
+    :returns: The imported module.
+    :raises FileNotFoundError: If the path does not exist.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(import_path, file_path)
+        if spec is None:
+            raise RuntimeError("Imported module spec is unexpectedly 'None'")
+        if spec.loader is None:
+            raise RuntimeError("Imported module spec loader is unexpectedly 'None'")
+
+        module = importlib.util.module_from_spec(spec)
+        with edit_sys_path(prepend=[file_path.parent]):
+            sys.modules[import_path] = module
+            spec.loader.exec_module(module)
+    except ModuleNotFoundError as error:
+        if not file_path.exists():
+            raise FileNotFoundError(file_path) from error
+        raise
+
+    return module
+
+
+@contextmanager
+def edit_sys_path(prepend: Sequence[Path] = (), append: Sequence[Path] = ()) -> Generator[None, None, None]:
+    """
+    Temporarily add to :data:`sys.path` within a context manager.
+
+    :param prepend: A sequence of paths to add to :data:`sys.path` *before* the current entries.
+    :param append: A sequence of paths to add to :data:`sys.path` *after* the current entries.
+    :seealso: This is used to enable local imports for the :func:`import_py_file`.
+    """
+    original_sys_path = sys.path.copy()  # otherwise we just reference the original
+    try:
+        sys.path = [str(path) for path in prepend] + sys.path + [str(path) for path in append]
+        yield
+    finally:
+        sys.path = original_sys_path

--- a/concoursetools/metadata.py
+++ b/concoursetools/metadata.py
@@ -42,7 +42,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
         * ``BUILD_TEAM_ID``
         * ``BUILD_PIPELINE_ID``
 
-        These can still be accessed via :obj:`os.environ`, but they are not supported by Concourse Tools.
+        These can still be accessed via :data:`os.environ`, but they are not supported by Concourse Tools.
     """
     def __init__(self, BUILD_ID: str, BUILD_TEAM_NAME: str, ATC_EXTERNAL_URL: str, BUILD_NAME: str | None = None,
                  BUILD_JOB_NAME: str | None = None, BUILD_PIPELINE_NAME: str | None = None,
@@ -78,7 +78,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
     @property
     def is_one_off_build(self) -> bool:
         """
-        Return :obj:`True` if this build is one-off, and :obj:`False` otherwise.
+        Return :data:`True` if this build is one-off, and :data:`False` otherwise.
 
         A build is a "one-off" is it is triggered via the Concourse CLI
         :concourse:`execute command <tasks.running-tasks>`.
@@ -96,7 +96,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
 
     @property
     def is_instanced_pipeline(self) -> bool:
-        """Return :obj:`True` if this is an :concourse:`instanced pipeline <instanced-pipelines>`."""
+        """Return :data:`True` if this is an :concourse:`instanced pipeline <instanced-pipelines>`."""
         return self.BUILD_PIPELINE_INSTANCE_VARS is not None
 
     def instance_vars(self) -> dict[str, object]:
@@ -181,10 +181,10 @@ class BuildMetadata:  # pylint: disable=invalid-name
         :param additional_values: Additional values which can be used for interpolation.
                                   The keys of the mapping should not include the ``$`` character.
         :param ignore_missing: By default, if the variable is not available then a :class:`KeyError` will be raised.
-                               Setting this to :obj:`True` will ignore missing variables.
+                               Setting this to :data:`True` will ignore missing variables.
         :returns: The interpolated string.
         :seealso: Interpolation is done using an instance of :class:`string.Template` by calling either
-                  :meth:`~string.Template.substitute` when ``ignore_missing`` is :obj:`False`, and
+                  :meth:`~string.Template.substitute` when ``ignore_missing`` is :data:`False`, and
                   :meth:`~string.Template.safe_substitute` otherwise.
 
         :Example:

--- a/concoursetools/mocking.py
+++ b/concoursetools/mocking.py
@@ -27,7 +27,7 @@ def create_env_vars(one_off_build: bool = False, instance_vars: dict[str, str] |
     """
     Create fake environment variables for a Concourse stage.
 
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
 
@@ -79,7 +79,7 @@ class TestBuildMetadata(BuildMetadata):
 
         >>> metadata = BuildMetadata(**create_env_vars(...))
 
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -180,7 +180,7 @@ class TemporaryDirectoryState:
               of the file will be used instead.
             * A **folder** is represented by a dictionary yielding more files and folders.
 
-        If a folder has not been descended into (due to the depth limit) then it is represented by an :obj:`Ellipsis` (``...``).
+        If a folder has not been descended into (due to the depth limit) then it is represented by an :data:`Ellipsis` (``...``).
 
         :param folder_path: The path to the folder.
         :param max_depth: The maximum depth into which the function can descend. A value of 1 will not enter any subdirectories,
@@ -230,13 +230,13 @@ class TemporaryDirectoryState:
 
 class StringIOWrapper:
     r"""
-    A basic wrapper around a :class:`~io.StringIO` instance for capturing :obj:`~sys.stdout` and :obj:`~sys.stderr`.
+    A basic wrapper around a :class:`~io.StringIO` instance for capturing :data:`~sys.stdout` and :data:`~sys.stderr`.
 
     An instance of this class acts a bit like a string, to the extent that
     ``==`` will compare the :attr:`value` of the instance to a string.
 
     :Example:
-        Capture :obj:`~sys.stderr` with :meth:`capture_stderr`:
+        Capture :data:`~sys.stderr` with :meth:`capture_stderr`:
 
         >>> output = StringIOWrapper()
         >>> with output.capture_stderr():
@@ -246,7 +246,7 @@ class StringIOWrapper:
         >>> output == "def\n"
         True
 
-        Or capture both :obj:`~sys.stdout` and :obj:`~sys.stderr` with :meth:`capture_stdout_and_stderr`:
+        Or capture both :data:`~sys.stdout` and :data:`~sys.stderr` with :meth:`capture_stdout_and_stderr`:
 
         >>> output = StringIOWrapper()
         >>> with output.capture_stdout_and_stderr():
@@ -280,7 +280,7 @@ class StringIOWrapper:
     @contextmanager
     def capture_stdout_and_stderr(self) -> ContextManager["StringIOWrapper"]:
         """
-        Capture both :obj:`~sys.stdout` and :obj:`~sys.stderr`.
+        Capture both :data:`~sys.stdout` and :data:`~sys.stderr`.
 
         :seealso: :func:`contextlib.redirect_stdout`, :func:`contextlib.redirect_stderr`
         """
@@ -291,7 +291,7 @@ class StringIOWrapper:
     @contextmanager
     def capture_stderr(self) -> ContextManager["StringIOWrapper"]:
         """
-        Capture :obj:`~sys.stderr`.
+        Capture :data:`~sys.stderr`.
 
         :seealso: :func:`contextlib.redirect_stderr`
         """
@@ -302,7 +302,7 @@ class StringIOWrapper:
 @contextmanager
 def mock_environ(new_environ: dict[str, str]) -> ContextManager[None]:
     """
-    Mock :obj:`os.environ` in a context manager.
+    Mock :data:`os.environ` in a context manager.
 
     :param new_environ: The new environment variables. No existing environment variables are carried forward.
 
@@ -319,7 +319,7 @@ def mock_environ(new_environ: dict[str, str]) -> ContextManager[None]:
 @contextmanager
 def mock_stdin(stdin: str) -> ContextManager[None]:
     """
-    Mock :obj:`~sys.stdin` in a context manager.
+    Mock :data:`~sys.stdin` in a context manager.
 
     :param stdin: A new string to be used for the stdin.
 
@@ -329,9 +329,9 @@ def mock_stdin(stdin: str) -> ContextManager[None]:
         new_stdin
 
     .. warning::
-        As it's a :term:`file object`, :obj:`sys.stdin`
+        As it's a :term:`file object`, :data:`sys.stdin`
         is only mocked once by this decorator, and subsequent calls to
-        :meth:`~io.TextIOBase.read` will return :obj:`None`.
+        :meth:`~io.TextIOBase.read` will return :data:`None`.
     """
     with mock.patch.object(sys, "stdin", StringIO(stdin)):
         yield
@@ -340,7 +340,7 @@ def mock_stdin(stdin: str) -> ContextManager[None]:
 @contextmanager
 def mock_argv(*args: str) -> ContextManager[None]:
     """
-    Mock :obj:`sys.argv` in a context manager.
+    Mock :data:`sys.argv` in a context manager.
 
     :param args: New args to be used.
 

--- a/concoursetools/parsing.py
+++ b/concoursetools/parsing.py
@@ -31,7 +31,7 @@ def parse_check_payload(raw_json: str) -> tuple[ResourceConfig, VersionConfig | 
     :returns: The source and version configuration (if it exists).
 
     .. note::
-        If the version has not been passed, then :obj:`None` will be returned, and **not** an empty :class:`dict`.
+        If the version has not been passed, then :data:`None` will be returned, and **not** an empty :class:`dict`.
     """
     payload: dict[str, dict[str, object] | None] = json.loads(raw_json)
     source_config = _extract_source_config_from_payload(payload)
@@ -178,7 +178,7 @@ def format_check_input(resource_config: ResourceConfig, version_config: VersionC
     Format :concourse:`check input <implementing-resource-types.resource-check>` as a JSON string.
 
     :param resource_config: A resource configuration.
-    :param version_config: A version configuration, or :obj:`None` if no version currently exists.
+    :param version_config: A version configuration, or :data:`None` if no version currently exists.
     :param json_kwargs: Additional keyword arguments to pass to :func:`json.dumps`.
     :returns: A formatted JSON string as Concourse will pass to a Check:
 

--- a/concoursetools/resource.py
+++ b/concoursetools/resource.py
@@ -104,7 +104,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         Fetch new versions of the resource.
 
         The method will be passed the previous version (an instance of the :class:`~concoursetools.version.Version`
-        class) if it exists, or :obj:`None` if this is the first version. It should return a list of version instances
+        class) if it exists, or :data:`None` if this is the first version. It should return a list of version instances
         in **chronological order with the oldest first**, "including the requested version if it's still valid.".
 
         .. attention::
@@ -119,7 +119,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
             newer versions due to something wrong with the external resource, such as a git repo which has been
             force pushed and can no longer be properly compared.
 
-        :param previous_version: The most recent version of the resource. This will be set to :obj:`None`
+        :param previous_version: The most recent version of the resource. This will be set to :data:`None`
                                  if the resource has never been run before.
         :returns: A list of new versions.
         """

--- a/concoursetools/testing.py
+++ b/concoursetools/testing.py
@@ -46,7 +46,7 @@ class TestResourceWrapper(ABC, Generic[VersionT]):
         methods to capture the debugging output and directory state changes respectively.
 
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
 
@@ -151,7 +151,7 @@ class SimpleTestResourceWrapper(TestResourceWrapper[VersionT]):
 
     :param inner_resource: The resource to be wrapped.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -167,7 +167,7 @@ class SimpleTestResourceWrapper(TestResourceWrapper[VersionT]):
 
         Calls the inner resource whilst capturing debugging output.
 
-        :param previous_version: The most recent version of the resource. This will be set to :obj:`None`
+        :param previous_version: The most recent version of the resource. This will be set to :data:`None`
                                  if the resource has never been run before.
         :returns: A list of new versions.
         """
@@ -214,7 +214,7 @@ class JSONTestResourceWrapper(TestResourceWrapper[VersionT]):
     :param inner_resource_type: The :class:`~concoursetools.resource.ConcourseResource` subclass corresponding to the resource.
     :param inner_resource_config: The JSON configuration for the resource.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -235,7 +235,7 @@ class JSONTestResourceWrapper(TestResourceWrapper[VersionT]):
             No environment variables are available to the check script.
 
         :param previous_version_config: The JSON configuration of the most recent version of the resource.
-                                        This will be set to :obj:`None` if the resource has never been run before.
+                                        This will be set to :data:`None` if the resource has never been run before.
         :returns: A list of new version configurations.
         """
         stdin = format_check_input(self.inner_resource_config, previous_version_config)
@@ -325,7 +325,7 @@ class ConversionTestResourceWrapper(JSONTestResourceWrapper[VersionT]):
     :param inner_resource_type: The :class:`~concoursetools.resource.ConcourseResource` subclass corresponding to the resource.
     :param inner_resource_config: The JSON configuration for the resource.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -344,7 +344,7 @@ class ConversionTestResourceWrapper(JSONTestResourceWrapper[VersionT]):
         Converts the version (if it exists) to JSON, and then invokes :meth:`~JSONTestResourceWrapper.fetch_new_versions`.
         The response is then converted back to :class:`~concoursetools.version.Version` instances.
 
-        :param previous_version: The most recent version of the resource. This will be set to :obj:`None`
+        :param previous_version: The most recent version of the resource. This will be set to :data:`None`
                                  if the resource has never been run before.
         :returns: A list of new versions.
         """
@@ -398,16 +398,16 @@ class FileTestResourceWrapper(TestResourceWrapper[Version]):
 
     :param inner_resource_config: The JSON configuration for the resource.
     :param check_script: The path to the external script for the :concourse:`check <implementing-resource-types.resource-check>`.
-                         Setting to :obj:`None` (default) means that :meth:`fetch_new_versions`
+                         Setting to :data:`None` (default) means that :meth:`fetch_new_versions`
                          raises :class:`NotImplementedError`.
     :param in_script: The path to the external script for the :concourse:`check <implementing-resource-types.resource-in>`.
-                      Setting to :obj:`None` (default) means that :meth:`download_version`
+                      Setting to :data:`None` (default) means that :meth:`download_version`
                       raises :class:`NotImplementedError`.
     :param out_script: The path to the external script for the :concourse:`check <implementing-resource-types.resource-out>`.
-                       Setting to :obj:`None` (default) means that :meth:`publish_new_version`
+                       Setting to :data:`None` (default) means that :meth:`publish_new_version`
                        raises :class:`NotImplementedError`.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
 
@@ -432,7 +432,7 @@ class FileTestResourceWrapper(TestResourceWrapper[Version]):
             No environment variables are available to the check script.
 
         :param previous_version_config: The JSON configuration of the most recent version of the resource.
-                                        This will be set to :obj:`None` if the resource has never been run before.
+                                        This will be set to :data:`None` if the resource has never been run before.
         :returns: A list of new version configurations.
         """
         if self.check_script is None:
@@ -526,7 +526,7 @@ class FileTestResourceWrapper(TestResourceWrapper[Version]):
                            If not found, then no error will be raised unless the corresponding
                            method is called.
         :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-        :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+        :param one_off_build: Set to :data:`True` if you are testing a one-off build.
         :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
         :param env_vars: Pass additional environment variables, or overload the default ones.
         """
@@ -554,10 +554,10 @@ class FileConversionTestResourceWrapper(FileTestResourceWrapper, Generic[Version
     :param permissions: The (Linux) permissions the file should have. Defaults to ``rwxr-xr-x``.
                         (See :func:`~concoursetools.dockertools.create_script_file`.)
     :param encoding: The encoding of the file as passed to :meth:`~pathlib.Path.write_text`.
-                     Setting to :obj:`None` (default) will use the user's default encoding.
+                     Setting to :data:`None` (default) will use the user's default encoding.
                      (See :func:`~concoursetools.dockertools.create_script_file`.)
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -585,7 +585,7 @@ class FileConversionTestResourceWrapper(FileTestResourceWrapper, Generic[Version
         .. caution::
             The external script file only exists for the duration of this method and is not cached.
 
-        :param previous_version: The most recent version of the resource. This will be set to :obj:`None`
+        :param previous_version: The most recent version of the resource. This will be set to :data:`None`
                                  if the resource has never been run before.
         :returns: A list of new versions.
         """
@@ -663,7 +663,7 @@ class DockerTestResourceWrapper(TestResourceWrapper[Version]):
     :param inner_resource_config: The JSON configuration for the resource.
     :param image: The Docker image to use, which must exist in the local cache. Passed verbatim to ``docker run``.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
 
@@ -691,7 +691,7 @@ class DockerTestResourceWrapper(TestResourceWrapper[Version]):
             No environment variables are available to the check script.
 
         :param previous_version_config: The JSON configuration of the most recent version of the resource.
-                                        This will be set to :obj:`None` if the resource has never been run before.
+                                        This will be set to :data:`None` if the resource has never been run before.
         :returns: A list of new version configurations.
         """
         stdin = format_check_input(self.inner_resource_config, previous_version_config)
@@ -777,7 +777,7 @@ class DockerConversionTestResourceWrapper(DockerTestResourceWrapper, Generic[Ver
     :param inner_resource_config: The JSON configuration for the resource.
     :param image: The Docker image to use, which must exist in the local cache. Passed verbatim to ``docker run``.
     :param directory_dict: The initial state of the resource directory. See :class:`~concoursetools.mocking.TemporaryDirectoryState`
-    :param one_off_build: Set to :obj:`True` if you are testing a one-off build.
+    :param one_off_build: Set to :data:`True` if you are testing a one-off build.
     :param instance_vars: Pass optional instance vars to emulate an instanced pipeline.
     :param env_vars: Pass additional environment variables, or overload the default ones.
     """
@@ -797,7 +797,7 @@ class DockerConversionTestResourceWrapper(DockerTestResourceWrapper, Generic[Ver
         Converts the version (if it exists) to JSON and then invokes :meth:`~DockerTestResourceWrapper.fetch_new_versions`.
         The response is then converted back to :class:`~concoursetools.version.Version` instances.
 
-        :param previous_version: The most recent version of the resource. This will be set to :obj:`None`
+        :param previous_version: The most recent version of the resource. This will be set to :data:`None`
                                  if the resource has never been run before.
         :returns: A list of new versions.
         """
@@ -864,14 +864,14 @@ def run_docker_container(image: str, command: str, additional_args: list[str] | 
     :param additional_args: Additional arguments to pass to the command.
     :param env: Environment variables to be made available to the script.
     :param cwd: Pass a path within the container to set the working directory, or else use the image default.
-    :param stdin: A string to be passed on :obj:`~sys.stdin`.
-    :param rm: Set to :obj:`True` to automatically remove the container when it exits.
+    :param stdin: A string to be passed on :data:`~sys.stdin`.
+    :param rm: Set to :data:`True` to automatically remove the container when it exits.
                 Equivalent to passing ``--rm``.
-    :param interactive: Set to :obj:`True` to keep ``stdin`` open even if not attached.
+    :param interactive: Set to :data:`True` to keep ``stdin`` open even if not attached.
                         Equivalent to passing ``-i`` or ``--interactive``.
     :param dir_mapping: A mapping of directories to paths to mount within the container. Values can be paths or strings.
     :param hostname: Specify a hostname inside the container. Defaults to the container ID.
-    :param local_only: When set to :obj:`True` (default), only locally cached images can be used.
+    :param local_only: When set to :data:`True` (default), only locally cached images can be used.
     :returns: The stdout and stderr of the script.
     :raises RuntimeError: If the external script exits with a non-zero exit code.
     :seealso: This function will call :func:`run_command`.
@@ -919,7 +919,7 @@ def run_script(script_path: Path, additional_args: list[str] | None = None, env:
     :param additional_args: Additional arguments to be passed to the script.
     :param env: Environment variables to be made available to the script.
     :param cwd: The working directory of the script. Defaults to current working directory.
-    :param stdin: A string to be passed on :obj:`~sys.stdin`.
+    :param stdin: A string to be passed on :data:`~sys.stdin`.
     :returns: The stdout and stderr of the script.
     :raises FileNotFoundError: If the script does not exist.
     :raises RuntimeError: If the external script exits with a non-zero exit code.
@@ -940,7 +940,7 @@ def run_command(command: str, additional_args: list[str] | None = None, env: dic
     :param additional_args: Additional arguments to be passed to the command.
     :param env: Environment variables to be made available to the command.
     :param cwd: The working directory of the command. Defaults to current working directory.
-    :param stdin: A string to be passed on :obj:`~sys.stdin`.
+    :param stdin: A string to be passed on :data:`~sys.stdin`.
     :returns: The stdout and stderr of the command.
     :raises RuntimeError: If the external command exits with a non-zero exit code.
     :seealso: This function is broadly equivalent to :func:`subprocess.run`.

--- a/concoursetools/version.py
+++ b/concoursetools/version.py
@@ -130,7 +130,7 @@ class Version(ABC):
         :Example:
 
             A user may wish to include whether or not the commit is a "merge commit" within
-            the version. However, :code:`bool("False")` will still return :obj:`True`.
+            the version. However, :code:`bool("False")` will still return :data:`True`.
             Instead, the user should do something like this:
 
             .. code-block:: python3
@@ -160,7 +160,7 @@ class SortableVersionMixin(ABC):
     A mixin for :class:`Version` subclasses which allows comparisons between instances.
 
     .. note::
-        Once :obj:`~object.__lt__` has been implemented, you will be able to use ``<``, ``>``, ``<=`` and ``>=`` with your version classes.
+        Once :meth:`~object.__lt__` has been implemented, you will be able to use ``<``, ``>``, ``<=`` and ``>=`` with your version classes.
 
     :Example:
         >>> import datetime

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -20,6 +20,7 @@ words:
   - bysource
   - classmethod
   - Colors
+  - colspec
   - concoursetools
   - dataclass
   - dataclasses
@@ -47,6 +48,7 @@ words:
   - pathlib
   - pyobject
   - Quickstart
+  - refid
   - refuri
   - rstrip
   - rwxr
@@ -54,6 +56,8 @@ words:
   - srcset
   - stringifying
   - termcolor
+  - tgroup
+  - thead
   - toctree
   - typehints
   - undoc

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,22 @@
+Command Line
+============
+
+.. automodule:: concoursetools.cli.parser
+    :members:
+    :exclude-members: Parameter, PositionalArgument, Option, FlagOption
+
+
+.. autoclass:: concoursetools.cli.docstring.Docstring
+    :members:
+
+Parameters
+----------
+
+.. autoclass:: concoursetools.cli.parser.PositionalArgument
+
+.. autoclass:: concoursetools.cli.parser.Option
+
+.. autoclass:: concoursetools.cli.parser.FlagOption
+
+.. autoclass:: concoursetools.cli.parser.Parameter
+    :members:

--- a/docs/source/cli_reference.rst
+++ b/docs/source/cli_reference.rst
@@ -1,0 +1,8 @@
+CLI Reference
+=============
+
+Concourse Tools contains a CLI for a number of small tasks to help write and deploy resource types.
+
+
+.. cli:: concoursetools.cli.cli
+    :align: left

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,7 @@ sys.path.extend([str(DOCS_FOLDER_PATH), str(SOURCE_FOLDER_PATH), str(REPO_FOLDER
 
 import concoursetools
 import concoursetools.additional
+import concoursetools.importing
 import concoursetools.resource
 import concoursetools.typing
 import concoursetools.version
@@ -54,6 +55,7 @@ always_document_param_types = True
 autodoc_member_order = "bysource"
 
 autodoc_custom_types = {
+    concoursetools.importing.T: ":class:`object`",
     concoursetools.typing.VersionT: ":class:`~concoursetools.version.Version`",
     concoursetools.typing.SortableVersionT: ":class:`~concoursetools.version.Version`",
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,11 +7,13 @@ For a full list see the documentation: https://www.sphinx-doc.org/en/master/usag
 """
 # -- Path setup --------------------------------------------------------------
 
+from collections.abc import Callable
 from pathlib import Path
 import sys
 from typing import Any
 
 import sphinx.config
+from sphinx_autodoc_typehints import format_annotation
 
 CONF_FILE_PATH = Path(__file__).absolute()
 SOURCE_FOLDER_PATH = CONF_FILE_PATH.parent
@@ -23,6 +25,7 @@ sys.path.extend([str(DOCS_FOLDER_PATH), str(SOURCE_FOLDER_PATH), str(REPO_FOLDER
 
 import concoursetools
 import concoursetools.additional
+import concoursetools.cli.parser
 import concoursetools.importing
 import concoursetools.resource
 import concoursetools.typing
@@ -43,6 +46,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",
+    "extensions.cli",
     "extensions.concourse",
     "extensions.linecount",
     "extensions.wikipedia",
@@ -55,6 +59,7 @@ always_document_param_types = True
 autodoc_member_order = "bysource"
 
 autodoc_custom_types = {
+    concoursetools.cli.parser.CLIFunctionT: format_annotation(Callable[..., None], sphinx.config.Config()),
     concoursetools.importing.T: ":class:`object`",
     concoursetools.typing.VersionT: ":class:`~concoursetools.version.Version`",
     concoursetools.typing.SortableVersionT: ":class:`~concoursetools.version.Version`",

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -68,13 +68,8 @@ It is these files which get called by Concourse as part of the resource. Note th
 
 .. tip::
 
-    Because this pattern is suitable for almost every resource type, you can automate the creation of the ``assets`` folder by running ``python3 -m concoursetools assets``. You can also pass the following options:
-
-    * ``-e``, ``--executable``: The python executable to place at the top of the file. Defaults to ``/usr/bin/env python3``.
-    * ``-r``, ``--resource-file``: The path to your resource module. Defaults to ``concourse.py``.
-    * ``-c``, ``--class-name``: The name of the resource class to import from the module. If there is only one subclass of :class:`~concoursetools.resource.ConcourseResource`, then this will be automatically selected. If there are multiple subclasses and this option is not set then an error will be raised.
-
-    This corresponds to the :func:`~concoursetools.dockertools.create_asset_scripts` function.
+    Because this pattern is suitable for almost every resource type, you can automate the creation of the ``assets``
+    folder with the :ref:`cli.assets` CLI command.
 
 Dockerfile
 ----------
@@ -92,7 +87,7 @@ The Dockerfile should look something like:
 
     WORKDIR /opt/resource/
     COPY concourse.py ./concourse.py
-    RUN python3 -m concoursetools . -r concourse.py
+    RUN python3 -m concoursetools assets . -r concourse.py
 
     ENTRYPOINT ["python3"]
 
@@ -100,15 +95,7 @@ You should adjust the base image according to your requirements. If you **cannot
 
 .. tip::
 
-    You can automate the creation of this file with
-
-    .. code:: shell
-
-        $ python3 -m concoursetools --docker .
-
-    The same arguments from the :ref:`previous section <Assets>` can also be passed here, and will be used by the inner call to the CLI.
-
-    This corresponds to the :func:`~concoursetools.dockertools.create_dockerfile` function.
+    You can automate the creation of this file with the :ref:`cli.dockerfile` CLI command.
 
 
 Including Certs in your Docker Build
@@ -146,7 +133,7 @@ If any of your requirements are private (Concourse Tools is not a public project
 
     WORKDIR /opt/resource/
     COPY concourse.py ./concourse.py
-    RUN python3 -m concoursetools . -r concourse.py
+    RUN python3 -m concoursetools assets . -r concourse.py
 
     ENTRYPOINT ["python3"]
 
@@ -164,11 +151,11 @@ The Python :mod:`venv` module is necessary to easily copy the installed requirem
 
 .. tip::
 
-    You can easily generate this skeleton with
+    You can easily generate this skeleton with the :ref:`cli.dockerfile` CLI command:
 
     .. code:: shell
 
-        $ python3 -m concoursetools --docker . --include-rsa
+        $ python3 -m concoursetools dockerfile . --include-rsa
 
 Dockertools Reference
 ---------------------

--- a/docs/source/examples/build_status.rst
+++ b/docs/source/examples/build_status.rst
@@ -119,7 +119,7 @@ Remember creating that Build Status enum? We should make use of it here:
     :end-at: {possible_values}
     :dedent:
 
-Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :obj:`sys.argv`), but is also a :class:`~pathlib.Path` instance, which makes the code a bit shorter:
+Next we need to fetch the commit hash (if it hasn't already been set). This is more or less a direct lift from the `original code <https://github.com/SHyx0rmZ/bitbucket-build-status-resource/blob/v1.6.0/scripts/out#L49>`_, except we can make use of the fact that ``sources_dir`` is both already available to us (no shenanigans with :data:`sys.argv`), but is also a :class:`~pathlib.Path` instance, which makes the code a bit shorter:
 
 .. literalinclude:: ../../../examples/build_status.py
     :pyobject: Resource.publish_new_version

--- a/docs/source/examples/pipeline.rst
+++ b/docs/source/examples/pipeline.rst
@@ -59,13 +59,13 @@ ________________________
 
 The first behaviour we will implement is the :concourse:`check <implementing-resource-types.resource-check>`, when the external resource is queried for new executions. There are a few cases that we need to handle:
 
-1. If no previous version is passed (i.e., the parameter is :obj:`None`), then we know that this is the first request and we need to return the *latest valid version*.
+1. If no previous version is passed (i.e., the parameter is :data:`None`), then we know that this is the first request and we need to return the *latest valid version*.
 2. If no versions are available *at all* then an empty list should be returned.
 3. If there are new executions which have finished since the previous version, then they need to be returned in "oldest-to-newest" order, including the previous version "if it's still valid".
 4. If there have been no more executions since the previous version then the response should *only* include the previous version.
 5. If the previous version is no longer in the set of versions (i.e., something has gone wrong or the external resource has somehow changed) then the latest version should be returned. In practice this rarely happens, but should be planned for.
 
-We start by defining a private method on the resource to yield "potential versions" from the external source. This is just to allow us to check equality with the previous version directly, which is cleaner than worrying about a potential :class:`AttributeError` if the previous version is :obj:`None`. It also allows us to handle the way in which AWS batches up its response when calling `list_pipeline_executions <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_pipeline_executions.html>`_. All we need be concerned with is that this method will yield instances of ``ExecutionVersion`` in newest-to-oldest order until the server runs out.
+We start by defining a private method on the resource to yield "potential versions" from the external source. This is just to allow us to check equality with the previous version directly, which is cleaner than worrying about a potential :class:`AttributeError` if the previous version is :data:`None`. It also allows us to handle the way in which AWS batches up its response when calling `list_pipeline_executions <https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_pipeline_executions.html>`_. All we need be concerned with is that this method will yield instances of ``ExecutionVersion`` in newest-to-oldest order until the server runs out.
 
 .. literalinclude:: ../../../examples/pipeline.py
     :pyobject: PipelineResource._yield_potential_execution_versions
@@ -99,7 +99,7 @@ We start by describing the execution, removing the ``ResponseMetadata`` (no reas
 .. literalinclude:: ../../../examples/pipeline.py
     :pyobject: DatetimeSafeJSONEncoder
 
-Next, we check if the user wishes to download the pipeline, and then write the definition to file. Again, each of these are configurable and the defaults are handled with default parameters. Finally, we create the metadata. It is a lot easier to deal with a Python :class:`dict` than JSON in bash, and we can take advantage of the numerous ways to update and mutate the dictionary. Here, we specifically filter out any pieces of metadata with a value of :obj:`None` to reduce the amount of code we need to write. Finally, both the original version and the metadata are returned.
+Next, we check if the user wishes to download the pipeline, and then write the definition to file. Again, each of these are configurable and the defaults are handled with default parameters. Finally, we create the metadata. It is a lot easier to deal with a Python :class:`dict` than JSON in bash, and we can take advantage of the numerous ways to update and mutate the dictionary. Here, we specifically filter out any pieces of metadata with a value of :data:`None` to reduce the amount of code we need to write. Finally, both the original version and the metadata are returned.
 
 Publishing New Executions
 _________________________

--- a/docs/source/examples/xkcd.rst
+++ b/docs/source/examples/xkcd.rst
@@ -63,7 +63,7 @@ Next we write the metadata to a file, in case the user wishes to use it themselv
     :start-at: info_path =
     :end-before: if image
 
-We optionally (but defaulting to :obj:`True`) download the image:
+We optionally (but defaulting to :data:`True`) download the image:
 
 .. literalinclude:: ../../../examples/xkcd.py
     :pyobject: XKCDResource.download_version

--- a/docs/source/extensions/cli.py
+++ b/docs/source/extensions/cli.py
@@ -1,0 +1,127 @@
+# (C) Crown Copyright GCHQ
+"""
+Sphinx extension for documenting the custom CLI.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
+from sphinx.ext.autodoc import import_object
+from sphinx.util.docutils import SphinxDirective
+
+from concoursetools.cli.parser import CLI
+
+
+def _align_directive(argument: str) -> str:
+    return directives.choice(argument, ("left", "center", "right"))
+
+
+class CLIDirective(SphinxDirective):
+    """
+    Directive for listing CLI commands in a table.
+    """
+    required_arguments = 1  # The import path of the CLI
+    option_spec = {
+        "align": _align_directive,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        """
+        Process the content of the shield directive.
+        """
+        align: Literal["left", "center", "right"] | None = self.options.get("align")
+
+        headers = [nodes.entry("", nodes.paragraph("", header)) for header in ["Command", "Description"]]
+
+        import_string, = self.arguments
+        cli = self.import_cli(import_string)
+
+        rows: list[list[nodes.entry]] = []
+
+        for command_name, command in cli.commands.items():
+            rows.append([
+                nodes.entry("", nodes.paragraph("", "", nodes.reference("", "", nodes.literal("", command_name), refid=f"cli.{command_name}"))),
+                nodes.entry("", nodes.paragraph("", command.description or "")),
+            ])
+
+        table = self.create_table(headers, rows, align=align)
+
+        nodes_to_return: list[nodes.Node] = [table]
+
+        for command_name, command in cli.commands.items():
+            command_section = nodes.section(ids=[f"cli.{command_name}"])
+            title = nodes.title(f"cli.{command_name}", "", nodes.literal("", command_name))
+            command_section.append(title)
+
+            if command.description is not None:
+                command_section.append(nodes.paragraph("", command.description))
+
+            usage_block = nodes.literal_block("", f"$ {command.usage_string()}")
+            command_section.append(usage_block)
+
+            for positional in command.positional_arguments:
+                alias_paragraph = nodes.paragraph("", "", nodes.literal("", positional.name))
+                description_paragraph = nodes.paragraph("", positional.description or "")
+                description_paragraph.set_class("cli-option-description")
+                command_section.extend([alias_paragraph, description_paragraph])
+
+            for option in command.options:
+                alias_nodes: list[nodes.Node] = []
+                for alias in option.aliases:
+                    alias_nodes.append(nodes.literal("", alias))
+                    alias_nodes.append(nodes.Text(", "))
+                alias_paragraph = nodes.paragraph("", "", *alias_nodes[:-1])
+                description_paragraph = nodes.paragraph("", option.description or "")
+                description_paragraph.set_class("cli-option-description")
+                command_section.extend([alias_paragraph, description_paragraph])
+
+            nodes_to_return.append(command_section)
+
+        return nodes_to_return
+
+    def create_table(self, headers: list[nodes.entry], rows: list[list[nodes.entry]],
+                     align: Literal["left", "center", "right"] | None = None) -> nodes.table:
+        table = nodes.table()
+        if align is not None:
+            table["align"] = align
+
+        table_group = nodes.tgroup(cols=len(headers))
+        table_group.extend([nodes.colspec()] * len(headers))
+
+        table.append(table_group)
+
+        header = nodes.thead()
+        header_row = nodes.row()
+        header_row.extend(headers)
+        header.append(header_row)
+        table_group.append(header)
+
+        body = nodes.tbody()
+        for row in rows:
+            body_row = nodes.row()
+            body_row.extend(row)
+            body.append(body_row)
+
+        table_group.append(body)
+        return table
+
+    def import_cli(self, import_string: str) -> CLI:
+        *module_components, import_object_name = import_string.split(".")
+        import_path = ".".join(module_components)
+
+        import_result = import_object(import_path, [import_object_name])
+        cli: CLI = import_result[-1]
+        return cli
+
+
+def setup(app: Sphinx) -> dict[str, object]:
+    """
+    Attach the extension to the application.
+
+    :param app: The Sphinx application.
+    """
+    app.add_directive("cli", CLIDirective)
+    return {"parallel_read_safe": True}

--- a/docs/source/importing.rst
+++ b/docs/source/importing.rst
@@ -1,0 +1,5 @@
+Dynamic Importing
+=================
+
+.. automodule:: concoursetools.importing
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ Contents
 
     quickstart
     api_reference
+    cli_reference
     debugging
     testing
     deployment

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -5,5 +5,6 @@ Concourse Tools contains a number of internal utility functions which may be use
 
 .. toctree::
     parsing
+    importing
     main_scripts
     typing

--- a/docs/source/internals.rst
+++ b/docs/source/internals.rst
@@ -5,6 +5,7 @@ Concourse Tools contains a number of internal utility functions which may be use
 
 .. toctree::
     parsing
+    cli
     importing
     main_scripts
     typing

--- a/docs/source/version.rst
+++ b/docs/source/version.rst
@@ -49,7 +49,7 @@ By default, two versions are equal if they have the same :func:`hash`. However, 
         def __init__(self, branch_name: str):
             self.branch_name = branch_name
 
-Under the default behaviour, ``GitBranch("main")`` and ``GitBranch("origin/main")`` will be not be considered equal, but this might not be ideal. The fastest way to fix this is to overload :obj:`~object.__eq__` like so:
+Under the default behaviour, ``GitBranch("main")`` and ``GitBranch("origin/main")`` will be not be considered equal, but this might not be ideal. The fastest way to fix this is to overload :meth:`~object.__eq__` like so:
 
 .. code:: python3
 
@@ -65,7 +65,7 @@ Under the default behaviour, ``GitBranch("main")`` and ``GitBranch("origin/main"
 Ordering
 ________
 
-Sometimes you need to order versions to simplify your scripts (returning the latest version, etc.), but by default versions are **not** comparable in this way. This can be fixed by also inheriting from :class:`SortableVersionMixin`, which expects you to implement :obj:`~object.__lt__`. We want ``version_a <= version_b`` if and only if ``version_a`` is **no older** than ``version_b``.
+Sometimes you need to order versions to simplify your scripts (returning the latest version, etc.), but by default versions are **not** comparable in this way. This can be fixed by also inheriting from :class:`SortableVersionMixin`, which expects you to implement :meth:`~object.__lt__`. We want ``version_a <= version_b`` if and only if ``version_a`` is **no older** than ``version_b``.
 
 .. autoclass:: concoursetools.version.SortableVersionMixin
     :members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,11 @@ omit = ["concoursetools/colour.py", "concoursetools/typing.py", "*/__init__.py",
 [tool.coverage.report]
 sort = "Cover"
 exclude_lines = [
+    "@abstractmethod",
     "def __repr__",
     "pass",
     "raise$",
-    "raise RuntimeError"
+    "raise RuntimeError",
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ zip_safe = False
 python_requires = >=3.9
 packages =
     concoursetools
+    concoursetools.cli
 
 [options.package_data]
 concoursetools = py.typed

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,87 @@
+# (C) Crown Copyright GCHQ
+from contextlib import redirect_stdout
+from io import StringIO
+import os
+from pathlib import Path
+import shutil
+import sys
+from tempfile import TemporaryDirectory
+import textwrap
+import unittest
+import unittest.mock
+
+from concoursetools.cli import cli
+from concoursetools.colour import Colour, colourise
+
+
+class LegacyTests(unittest.TestCase):
+    """
+    Tests for the creation of the Dockerfile.
+    """
+    def setUp(self) -> None:
+        """Code to run before each test."""
+        self._temp_dir = TemporaryDirectory()
+        self.temp_dir = Path(self._temp_dir.name)
+        self._original_dir = Path.cwd()
+
+        path_to_this_file = Path(__file__)
+        path_to_test_resource_module = path_to_this_file.parent / "resource.py"
+        shutil.copyfile(path_to_test_resource_module, self.temp_dir / "concourse.py")
+        self.dockerfile_path = self.temp_dir / "Dockerfile"
+        self.assertFalse(self.dockerfile_path.exists())
+
+        self.current_python_string = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+        os.chdir(self.temp_dir)
+
+    def tearDown(self) -> None:
+        """Code to run after each test."""
+        os.chdir(self._original_dir)
+        self._temp_dir.cleanup()
+
+    def test_docker(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            cli.invoke(["legacy", ".", "--docker"])
+
+        self.assertEqual(new_stdout.getvalue(), colourise(textwrap.dedent("""
+        The legacy CLI has been deprecated.
+        Please refer to the documentation or help pages for the up to date CLI.
+        This CLI will be removed in version 0.10.0, or in version 1.0.0, whichever is sooner.
+
+        """), colour=Colour.RED))
+
+        dockerfile_contents = self.dockerfile_path.read_text()
+        expected_contents = textwrap.dedent(f"""
+        FROM python:{self.current_python_string}-alpine
+
+        COPY requirements.txt requirements.txt
+
+        RUN python3 -m pip install --upgrade pip && \\
+            pip install -r requirements.txt --no-deps
+
+        WORKDIR /opt/resource/
+        COPY concourse.py ./concourse.py
+        RUN python3 -m concoursetools . -r concourse.py
+
+        ENTRYPOINT ["python3"]
+        """).lstrip()
+        self.assertEqual(dockerfile_contents, expected_contents)
+
+    def test_asset_scripts(self) -> None:
+        asset_dir = self.temp_dir / "assets"
+        self.assertFalse(asset_dir.exists())
+
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            cli.invoke(["legacy", "assets", "-c", "TestResource"])
+
+        self.assertEqual(new_stdout.getvalue(), colourise(textwrap.dedent("""
+        The legacy CLI has been deprecated.
+        Please refer to the documentation or help pages for the up to date CLI.
+        This CLI will be removed in version 0.10.0, or in version 1.0.0, whichever is sooner.
+
+        """), colour=Colour.RED))
+
+        self.assertTrue(asset_dir.exists())
+        self.assertSetEqual({path.name for path in asset_dir.iterdir()}, {"check", "in", "out"})

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -14,9 +14,43 @@ from concoursetools.cli import cli
 from concoursetools.colour import Colour, colourise
 
 
+class AssetTests(unittest.TestCase):
+    """
+    Tests for creation of the asset files.
+    """
+    def setUp(self) -> None:
+        """Code to run before each test."""
+        self._temp_dir = TemporaryDirectory()
+        self.temp_dir = Path(self._temp_dir.name)
+        self._original_dir = Path.cwd()
+
+        path_to_this_file = Path(__file__)
+        path_to_test_resource_module = path_to_this_file.parent / "resource.py"
+        shutil.copyfile(path_to_test_resource_module, self.temp_dir / "concourse.py")
+        os.chdir(self.temp_dir)
+
+    def tearDown(self) -> None:
+        """Code to run after each test."""
+        os.chdir(self._original_dir)
+        self._temp_dir.cleanup()
+
+    def test_asset_scripts(self) -> None:
+        asset_dir = self.temp_dir / "assets"
+        self.assertFalse(asset_dir.exists())
+
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            cli.invoke(["assets", "assets", "-c", "TestResource"])
+
+        self.assertEqual(new_stdout.getvalue(), "")
+
+        self.assertTrue(asset_dir.exists())
+        self.assertSetEqual({path.name for path in asset_dir.iterdir()}, {"check", "in", "out"})
+
+
 class LegacyTests(unittest.TestCase):
     """
-    Tests for the creation of the Dockerfile.
+    Tests for the legacy CLI.
     """
     def setUp(self) -> None:
         """Code to run before each test."""
@@ -62,7 +96,7 @@ class LegacyTests(unittest.TestCase):
 
         WORKDIR /opt/resource/
         COPY concourse.py ./concourse.py
-        RUN python3 -m concoursetools . -r concourse.py
+        RUN python3 -m concoursetools assets . -r concourse.py
 
         ENTRYPOINT ["python3"]
         """).lstrip()

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -1,0 +1,348 @@
+# (C) Crown Copyright GCHQ
+from collections.abc import Generator
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
+import json
+import shutil
+import textwrap
+import unittest
+import unittest.mock
+
+from concoursetools import __version__
+from concoursetools.cli.parser import CLI, Docstring
+
+
+class ParsingTests(unittest.TestCase):
+
+    def test_all_defaults(self) -> None:
+        args, kwargs = test_cli.commands["first_command"].parse_args(["abcd", "123"])
+        self.assertListEqual(args, ["abcd", 123])
+        self.assertDictEqual(kwargs, {
+            "option_1": "value",
+            "option_2": False,
+        })
+
+    def test_parsing_args(self) -> None:
+        args, kwargs = test_cli.commands["first_command"].parse_args(["abcd", "123", "--option-1", "new_value", "--option-2"])
+        self.assertListEqual(args, ["abcd", 123])
+        self.assertDictEqual(kwargs, {
+            "option_1": "new_value",
+            "option_2": True,
+        })
+
+    def test_parsing_shorter_args(self) -> None:
+        args, kwargs = test_cli.commands["first_command"].parse_args(["abcd", "123", "-o", "new_value", "--option-2"])
+        self.assertListEqual(args, ["abcd", 123])
+        self.assertDictEqual(kwargs, {
+            "option_1": "new_value",
+            "option_2": True,
+        })
+
+    def test_missing_positional(self) -> None:
+        with self.assertCLIError():
+            test_cli.commands["first_command"].parse_args([])
+
+    def test_incorrect_keyword(self) -> None:
+        with self.assertCLIError():
+            test_cli.commands["first_command"].parse_args([".", "--aption"])
+
+    @contextmanager
+    def assertCLIError(self) -> Generator[None, None, None]:
+        with self.assertRaises(SystemExit):
+            with redirect_stderr(StringIO()):
+                yield
+
+
+class InvokeTests(unittest.TestCase):
+
+    def test_defaults(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            test_cli.invoke(["first_command", "abcd", "123"])
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        {
+          "positional": {
+            "1": "abcd",
+            "2": 123
+          },
+          "optional": {
+            "1": "value",
+            "2": false
+          }
+        }
+        """).lstrip())
+
+    def test_args(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            test_cli.invoke(["first_command", "abcd", "123", "--option-1", "new_value", "--option-2"])
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        {
+          "positional": {
+            "1": "abcd",
+            "2": 123
+          },
+          "optional": {
+            "1": "new_value",
+            "2": true
+          }
+        }
+        """).lstrip())
+
+
+class HelpTests(unittest.TestCase):
+    """
+    Tests for the --help CLI option.
+    """
+    maxDiff = None
+
+    def test_version(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            test_cli.invoke(["--version"])
+
+        self.assertEqual(new_stdout.getvalue(), f"Concourse Tools v{__version__}\n")
+
+    def test_generic_help(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            test_cli.invoke(["--help"])
+
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        Usage:
+          python3 -m concoursetools <command> [OPTIONS]
+
+        Global Options:
+          -h, --help      Show this help message
+          -v, --version   Show the Concourse Tools version
+
+        Available Commands:
+          first_command   Invoke a test command.
+          second_command  Invoke a second test command.
+
+        """).lstrip())
+
+    def test_generic_help_no_arguments(self) -> None:
+        new_stdout = StringIO()
+        with redirect_stdout(new_stdout):
+            test_cli.invoke([])
+
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        Usage:
+          python3 -m concoursetools <command> [OPTIONS]
+
+        Global Options:
+          -h, --help      Show this help message
+          -v, --version   Show the Concourse Tools version
+
+        Available Commands:
+          first_command   Invoke a test command.
+          second_command  Invoke a second test command.
+
+        """).lstrip())
+
+    def first_command_help(self) -> None:
+        with self._mock_terminal_width(120):
+            width, _ = shutil.get_terminal_size()
+            self.assertGreaterEqual(width, 120)
+
+            new_stdout = StringIO()
+            with redirect_stdout(new_stdout):
+                test_cli.invoke(["first_command", "--help"])
+
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        Usage:
+          python3 -m concoursetools first_command <arg_1> <arg_2> [OPTIONS]
+
+        Global Options:
+          -h, --help      Show this help message
+
+        Command Arguments (required):
+          arg_1           The first positional argument.
+          arg_2           The second positional argument.
+
+        Command Options:
+          -o, --option-1  The first optional argument.
+          --option-2      The second optional argument.
+
+        """).lstrip())
+
+    def test_narrow_help_string(self) -> None:
+        with self._mock_terminal_width(80):
+            width, _ = shutil.get_terminal_size()
+            self.assertEqual(width, 80)
+
+            new_stdout = StringIO()
+            with redirect_stdout(new_stdout):
+                test_cli.invoke(["first_command", "--help"])
+
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        Usage:
+          python3 -m concoursetools first_command <arg_1> <arg_2> [OPTIONS]
+
+        Global Options:
+          -h, --help      Show this help message
+
+        Command Arguments (required):
+          arg_1           The first positional argument.
+          arg_2           The second positional argument.
+
+        Command Options:
+          -o, --option-1  The first optional argument.
+          --option-2      The second optional argument.
+
+        """).lstrip())
+
+    def test_narrower_help_string(self) -> None:
+        with self._mock_terminal_width(40):
+            width, _ = shutil.get_terminal_size()
+            self.assertEqual(width, 40)
+
+            new_stdout = StringIO()
+            with redirect_stdout(new_stdout):
+                test_cli.invoke(["first_command", "--help"])
+
+        self.assertEqual(new_stdout.getvalue(), textwrap.dedent("""
+        Usage:
+          python3 -m concoursetools \\
+            first_command <arg_1> <arg_2> \\
+            [OPTIONS]
+
+        Global Options:
+          -h, --help      Show this help message
+
+        Command Arguments (required):
+          arg_1           The first positional
+                          argument.
+          arg_2           The second positional
+                          argument.
+
+        Command Options:
+          -o, --option-1  The first optional
+                          argument.
+          --option-2      The second optional
+                          argument.
+
+        """).lstrip())
+
+    @staticmethod
+    @contextmanager
+    def _mock_terminal_width(new_width: int) -> Generator[None, None, None]:
+        _, current_height = shutil.get_terminal_size()
+        with unittest.mock.patch("shutil.get_terminal_size", lambda: (new_width, current_height)):
+            yield
+
+
+class DocstringTests(unittest.TestCase):
+    """
+    Tests for the docstring parser.
+    """
+    def test_empty(self) -> None:
+
+        def func() -> None:
+            pass
+
+        docstring = Docstring.from_object(func)
+        self.assertEqual(docstring.first_line, "")
+        self.assertEqual(docstring.description, "")
+        self.assertDictEqual(docstring.parameters, {})
+
+    def test_one_line(self) -> None:
+
+        def func() -> None:
+            """A simple function."""
+            pass
+
+        docstring = Docstring.from_object(func)
+        self.assertEqual(docstring.first_line, "A simple function.")
+        self.assertEqual(docstring.description, "")
+        self.assertDictEqual(docstring.parameters, {})
+
+    def test_with_params(self) -> None:
+
+        def func() -> None:
+            """
+            A simple function.
+
+            :param param_1: A simple parameter.
+            :param param_2: A more complex parameter with a description that
+                            spans multiple lines.
+            """
+
+        docstring = Docstring.from_object(func)
+        self.assertEqual(docstring.first_line, "A simple function.")
+        self.assertEqual(docstring.description, "")
+        self.assertDictEqual(docstring.parameters, {
+            "param_1": "A simple parameter.",
+            "param_2": "A more complex parameter with a description that spans multiple lines.",
+        })
+
+    def test_multiline_with_params(self) -> None:
+
+        def func() -> None:
+            """
+            A simple function.
+
+            This is a more complex description that
+            spans multiple lines.
+
+            :param param_1: A simple parameter.
+            :param param_2: A more complex parameter with a description that
+                            spans multiple lines.
+            """
+
+        docstring = Docstring.from_object(func)
+        self.assertEqual(docstring.first_line, "A simple function.")
+        self.assertEqual(docstring.description, "This is a more complex description that\nspans multiple lines.")
+        self.assertDictEqual(docstring.parameters, {
+            "param_1": "A simple parameter.",
+            "param_2": "A more complex parameter with a description that spans multiple lines.",
+        })
+
+    def test_with_only_params(self) -> None:
+
+        def func() -> None:
+            """
+            :param param_1: A simple parameter.
+            :param param_2: A more complex parameter with a description that
+                            spans multiple lines.
+            """
+
+        docstring = Docstring.from_object(func)
+        self.assertEqual(docstring.first_line, "")
+        self.assertEqual(docstring.description, "")
+        self.assertDictEqual(docstring.parameters, {
+            "param_1": "A simple parameter.",
+            "param_2": "A more complex parameter with a description that spans multiple lines.",
+        })
+
+
+test_cli = CLI()
+
+
+@test_cli.register(allow_short={"option_1"})
+def first_command(arg_1: str, arg_2: int, /, *, option_1: str = "value", option_2: bool = False) -> None:
+    """
+    Invoke a test command.
+
+    :param arg_1: The first positional argument.
+    :param arg_2: The second positional argument.
+    :param option_1: The first optional argument.
+    :param option_2: The second optional argument.
+    """
+    command_json = {
+        "positional": {
+            "1": arg_1,
+            "2": arg_2,
+        },
+        "optional": {
+            "1": option_1,
+            "2": option_2
+        }
+    }
+    print(json.dumps(command_json, indent=2))
+
+
+@test_cli.register()
+def second_command() -> None:
+    """Invoke a second test command."""

--- a/tests/test_dockertools.py
+++ b/tests/test_dockertools.py
@@ -2,6 +2,7 @@
 """
 Tests for the dockertools module.
 """
+import inspect
 from pathlib import Path
 import shutil
 import sys
@@ -39,7 +40,10 @@ class BasicTests(TestCase):
             "SelfOrganisingConcourseResource": additional.SelfOrganisingConcourseResource,
             "TriggerOnChangeConcourseResource": additional.TriggerOnChangeConcourseResource,
         }
-        self.assertDictEqual(resource_classes, expected)
+        self.assertEqual(expected.keys(), resource_classes.keys())
+        for key, class_1 in resource_classes.items():
+            class_2 = expected[key]
+            self.assertClassEqual(class_1, class_2)
 
     def test_importing_class_no_name(self) -> None:
         file_path = Path(test_resource.__file__).relative_to(Path.cwd())
@@ -49,12 +53,7 @@ class BasicTests(TestCase):
     def test_importing_class_with_name(self) -> None:
         file_path = Path(test_resource.__file__).relative_to(Path.cwd())
         resource_class = import_resource_class_from_module(file_path, class_name=test_resource.TestResource.__name__)  # type: ignore[var-annotated]
-        self.assertEqual(resource_class, test_resource.TestResource)
-
-    def test_importing_class_no_options(self) -> None:
-        file_path = Path("pathlib.py")
-        with self.assertRaises(RuntimeError):
-            import_resource_class_from_module(file_path)
+        self.assertClassEqual(resource_class, test_resource.TestResource)
 
     def test_importing_class_multiple_options(self) -> None:
         file_path = Path(additional.__file__).relative_to(Path.cwd())
@@ -65,7 +64,11 @@ class BasicTests(TestCase):
         file_path = Path(additional.__file__).relative_to(Path.cwd())
         parent_class = additional.InOnlyConcourseResource
         resource_class = import_resource_class_from_module(file_path, class_name=parent_class.__name__)  # type: ignore[var-annotated]
-        self.assertEqual(resource_class, parent_class)
+        self.assertClassEqual(resource_class, parent_class)
+
+    def assertClassEqual(self, class_1: type[object], class_2: type[object]) -> None:
+        self.assertEqual(inspect.getsourcefile(class_1), inspect.getsourcefile(class_2))
+        self.assertEqual(inspect.getsource(class_1), inspect.getsource(class_2))
 
 
 class DockerTests(TestCase):

--- a/tests/test_dockertools.py
+++ b/tests/test_dockertools.py
@@ -2,11 +2,7 @@
 """
 Tests for the dockertools module.
 """
-from collections.abc import Generator
-from contextlib import contextmanager
-import os
 from pathlib import Path
-import secrets
 import shutil
 import sys
 from tempfile import TemporaryDirectory
@@ -51,7 +47,7 @@ class DockerTests(TestCase):
 
         WORKDIR /opt/resource/
         COPY concourse.py ./concourse.py
-        RUN python3 -m concoursetools . -r concourse.py
+        RUN python3 -m concoursetools assets . -r concourse.py
 
         ENTRYPOINT ["python3"]
         """).lstrip()
@@ -71,7 +67,7 @@ class DockerTests(TestCase):
 
         WORKDIR /opt/resource/
         COPY resource.py ./resource.py
-        RUN python3 -m concoursetools . -r resource.py
+        RUN python3 -m concoursetools assets . -r resource.py
 
         ENTRYPOINT ["python3"]
         """).lstrip()
@@ -109,24 +105,24 @@ class DockerTests(TestCase):
 
         WORKDIR /opt/resource/
         COPY concourse.py ./concourse.py
-        RUN python3 -m concoursetools . -r concourse.py
+        RUN python3 -m concoursetools assets . -r concourse.py
 
         ENTRYPOINT ["python3"]
         """).lstrip()
         self.assertEqual(dockerfile_contents, expected_contents)
 
 
-@contextmanager
-def _chdir(new_dir: Path) -> Generator[None, None, None]:
-    original_dir = Path.cwd()
-    try:
-        os.chdir(new_dir)
-        yield
-    finally:
-        os.chdir(original_dir)
+# @contextmanager
+# def _chdir(new_dir: Path) -> Generator[None, None, None]:
+#     original_dir = Path.cwd()
+#     try:
+#         os.chdir(new_dir)
+#         yield
+#     finally:
+#         os.chdir(original_dir)
 
 
-def _random_python_file(num_bytes: int = 4, prefix: str = "test_") -> tuple[str, str]:
-    import_path = f"{prefix}{secrets.token_hex(num_bytes)}"
-    file_name = f"{import_path}.py"
-    return import_path, file_name
+# def _random_python_file(num_bytes: int = 4, prefix: str = "test_") -> tuple[str, str]:
+#     import_path = f"{prefix}{secrets.token_hex(num_bytes)}"
+#     file_name = f"{import_path}.py"
+#     return import_path, file_name

--- a/tests/test_importing.py
+++ b/tests/test_importing.py
@@ -1,0 +1,214 @@
+# (C) Crown Copyright GCHQ
+"""
+Tests for the dockertools module.
+"""
+from collections.abc import Generator
+from contextlib import contextmanager
+import inspect
+import os
+from pathlib import Path
+import secrets
+import sys
+from tempfile import TemporaryDirectory
+import textwrap
+from unittest import TestCase
+
+from concoursetools import ConcourseResource, additional
+from concoursetools.importing import (edit_sys_path, file_path_to_import_path, import_classes_from_module, import_py_file,
+                                      import_single_class_from_module)
+from tests import resource as test_resource
+
+
+class BasicTests(TestCase):
+    """
+    Tests for the utility functions.
+    """
+    def test_import_path_creation(self) -> None:
+        file_path = Path("path/to/python.py")
+        import_path = file_path_to_import_path(file_path)
+        self.assertEqual(import_path, "path.to.python")
+
+    def test_import_path_creation_wrong_extension(self) -> None:
+        file_path = Path("path/to/file.txt")
+        with self.assertRaises(ValueError):
+            file_path_to_import_path(file_path)
+
+    def test_importing_python_file_by_local_path_same_location(self) -> None:
+        file_contents = textwrap.dedent("""
+        def f(x: int, y: int) -> int:
+            return x + y
+        """).lstrip()
+
+        import_path, file_name = _random_python_file()
+        self.assertNotIn(import_path, sys.modules)
+
+        with TemporaryDirectory() as temp_dir:
+            py_file = Path(temp_dir) / file_name
+            py_file.write_text(file_contents)
+            with _chdir(Path(temp_dir)):
+                module = import_py_file(import_path, Path(file_name))
+
+        self.assertEqual(module.f(3, 5), 8)
+
+    def test_importing_python_file_by_full_path_same_location(self) -> None:
+        file_contents = textwrap.dedent("""
+        def f(x: int, y: int) -> int:
+            return x + y
+        """).lstrip()
+
+        import_path, file_name = _random_python_file()
+        self.assertNotIn(import_path, sys.modules)
+
+        with TemporaryDirectory() as temp_dir:
+            py_file = Path(temp_dir) / file_name
+            py_file.write_text(file_contents)
+            with _chdir(Path(temp_dir)):
+                module = import_py_file(import_path, py_file)
+
+        self.assertEqual(module.f(3, 5), 8)
+
+    def test_importing_python_file_by_full_path_other_location(self) -> None:
+        file_contents = textwrap.dedent("""
+        def f(x: int, y: int) -> int:
+            return x + y
+        """).lstrip()
+
+        import_path, file_name = _random_python_file()
+        self.assertNotIn(import_path, sys.modules)
+
+        with TemporaryDirectory() as temp_dir:
+            py_file = Path(temp_dir) / file_name
+            py_file.write_text(file_contents)
+
+            with TemporaryDirectory() as temp_dir_2:
+                with _chdir(Path(temp_dir_2)):
+                    self.assertNotIn(file_name, os.listdir("."))
+                    module = import_py_file(import_path, py_file)
+
+        self.assertEqual(module.f(3, 5), 8)
+
+    def test_importing_python_file_pair_by_full_path_other_location(self) -> None:
+        file_contents = textwrap.dedent("""
+        def f(x: int, y: int) -> int:
+            return x + y
+        """).lstrip()
+
+        import_path, file_name = _random_python_file()
+
+        second_file_contents = textwrap.dedent(f"""
+        from {import_path} import f
+
+        def g(x: int, y: int) -> int:
+            return f(x, 3) + f(y, 4)
+        """).lstrip()
+
+        second_import_path, second_file_name = _random_python_file()
+
+        self.assertNotIn(import_path, sys.modules)
+        self.assertNotIn(second_import_path, sys.modules)
+
+        with TemporaryDirectory() as temp_dir:
+            py_file = Path(temp_dir) / file_name
+            py_file.write_text(file_contents)
+
+            py_file_2 = Path(temp_dir) / second_file_name
+            py_file_2.write_text(second_file_contents)
+
+            with TemporaryDirectory() as temp_dir_2:
+                with _chdir(Path(temp_dir_2)):
+                    self.assertNotIn(file_name, os.listdir("."))
+                    self.assertNotIn(second_file_name, os.listdir("."))
+                    module = import_py_file(second_import_path, py_file_2)
+
+        self.assertEqual(module.g(3, 5), 15)
+
+    def test_changing_directory(self) -> None:
+        current_dir = Path.cwd()
+        with TemporaryDirectory() as temp_dir:
+            with _chdir(Path(temp_dir)):
+                self.assertEqual(Path.cwd(), Path(temp_dir).resolve())
+        self.assertEqual(Path.cwd(), current_dir.resolve())
+
+    def test_changing_directory_nested(self) -> None:
+        current_dir = Path.cwd()
+        with TemporaryDirectory() as temp_dir_1:
+            with TemporaryDirectory() as temp_dir_2:
+                with _chdir(Path(temp_dir_1)):
+                    self.assertEqual(Path.cwd(), Path(temp_dir_1).resolve())
+                    with _chdir(Path(temp_dir_2)):
+                        self.assertEqual(Path.cwd(), Path(temp_dir_2).resolve())
+                    self.assertEqual(Path.cwd(), Path(temp_dir_1).resolve())
+        self.assertEqual(Path.cwd(), current_dir.resolve())
+
+    def test_edit_sys_path(self) -> None:
+        original_sys_path = sys.path.copy()
+        with TemporaryDirectory() as temp_dir_1:
+            with TemporaryDirectory() as temp_dir_2:
+                self.assertNotIn(temp_dir_1, sys.path)
+                self.assertNotIn(temp_dir_2, sys.path)
+
+                with edit_sys_path(prepend=[Path(temp_dir_1)], append=[Path(temp_dir_2)]):
+                    self.assertEqual(sys.path[0], temp_dir_1)
+                    self.assertEqual(sys.path[-1], temp_dir_2)
+                    self.assertListEqual(sys.path[1:-1], original_sys_path)
+
+        self.assertNotIn(temp_dir_1, sys.path)
+        self.assertNotIn(temp_dir_2, sys.path)
+
+    def test_importing_classes(self) -> None:
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
+        resource_classes = import_classes_from_module(file_path, parent_class=ConcourseResource)  # type: ignore[type-abstract]
+        expected = {
+            "InOnlyConcourseResource": additional.InOnlyConcourseResource,
+            "OutOnlyConcourseResource": additional.OutOnlyConcourseResource,
+            "MultiVersionConcourseResource": additional.MultiVersionConcourseResource,
+            "SelfOrganisingConcourseResource": additional.SelfOrganisingConcourseResource,
+            "TriggerOnChangeConcourseResource": additional.TriggerOnChangeConcourseResource,
+        }
+        self.assertEqual(expected.keys(), resource_classes.keys())
+        for key, class_1 in resource_classes.items():
+            class_2 = expected[key]
+            self.assertClassEqual(class_1, class_2)
+
+    def test_importing_class_no_name(self) -> None:
+        file_path = Path(test_resource.__file__).relative_to(Path.cwd())
+        with self.assertRaises(RuntimeError):
+            import_single_class_from_module(file_path, parent_class=ConcourseResource)  # type: ignore[type-abstract]
+
+    def test_importing_class_with_name(self) -> None:
+        file_path = Path(test_resource.__file__).relative_to(Path.cwd())
+        resource_class = import_single_class_from_module(file_path, parent_class=ConcourseResource,  # type: ignore[type-abstract]
+                                                         class_name=test_resource.TestResource.__name__)
+        self.assertClassEqual(resource_class, test_resource.TestResource)
+
+    def test_importing_class_multiple_options(self) -> None:
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
+        with self.assertRaises(RuntimeError):
+            import_single_class_from_module(file_path, parent_class=ConcourseResource)  # type: ignore[type-abstract]
+
+    def test_importing_class_multiple_options_specify_name(self) -> None:
+        file_path = Path(additional.__file__).relative_to(Path.cwd())
+        parent_class = additional.InOnlyConcourseResource
+        resource_class = import_single_class_from_module(file_path, parent_class=ConcourseResource,  # type: ignore[type-abstract]
+                                                         class_name=parent_class.__name__)
+        self.assertClassEqual(resource_class, parent_class)
+
+    def assertClassEqual(self, class_1: type[object], class_2: type[object]) -> None:
+        self.assertEqual(inspect.getsourcefile(class_1), inspect.getsourcefile(class_2))
+        self.assertEqual(inspect.getsource(class_1), inspect.getsource(class_2))
+
+
+@contextmanager
+def _chdir(new_dir: Path) -> Generator[None, None, None]:
+    original_dir = Path.cwd()
+    try:
+        os.chdir(new_dir)
+        yield
+    finally:
+        os.chdir(original_dir)
+
+
+def _random_python_file(num_bytes: int = 4, prefix: str = "test_") -> tuple[str, str]:
+    import_path = f"{prefix}{secrets.token_hex(num_bytes)}"
+    file_name = f"{import_path}.py"
+    return import_path, file_name

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -9,7 +9,6 @@ from unittest import SkipTest, TestCase
 import concoursetools
 from concoursetools.cli import commands as cli_commands
 from concoursetools.colour import colourise
-from concoursetools.dockertools import Namespace, create_dockerfile
 from concoursetools.testing import (ConversionTestResourceWrapper, DockerConversionTestResourceWrapper, DockerTestResourceWrapper,
                                     FileConversionTestResourceWrapper, FileTestResourceWrapper, JSONTestResourceWrapper, SimpleTestResourceWrapper,
                                     run_command)
@@ -729,8 +728,7 @@ def _build_test_resource_docker_image() -> str:
             except FileNotFoundError:
                 pass
 
-        args = Namespace(str(temp_dir), resource_file="concourse.py", class_name=TestResource.__name__)
-        create_dockerfile(args, concoursetools_path=Path("concoursetools"))
+        cli_commands.dockerfile(str(temp_dir), resource_file="concourse.py", class_name=TestResource.__name__, dev=True)
 
         stdout, _ = run_command("docker", ["build", ".", "-q"], cwd=temp_dir)
         sha1_hash = stdout.strip()

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -7,8 +7,9 @@ from tempfile import TemporaryDirectory
 from unittest import SkipTest, TestCase
 
 import concoursetools
+from concoursetools.cli import commands as cli_commands
 from concoursetools.colour import colourise
-from concoursetools.dockertools import Namespace, create_asset_scripts, create_dockerfile
+from concoursetools.dockertools import Namespace, create_dockerfile
 from concoursetools.testing import (ConversionTestResourceWrapper, DockerConversionTestResourceWrapper, DockerTestResourceWrapper,
                                     FileConversionTestResourceWrapper, FileTestResourceWrapper, JSONTestResourceWrapper, SimpleTestResourceWrapper,
                                     run_command)
@@ -297,7 +298,8 @@ class FileWrapperTests(TestCase):
     def setUp(self) -> None:
         """Code to run before each test."""
         self.temp_dir = TemporaryDirectory()
-        create_asset_scripts(Path(self.temp_dir.name), TestResource, executable="/usr/bin/env python3")
+        cli_commands.assets(self.temp_dir.name, resource_file="tests/resource.py",
+                            class_name=TestResource.__name__, executable="/usr/bin/env python3")
 
         config = {
             "uri": "git://some-uri",


### PR DESCRIPTION
This PR adds in a new decorator-based CLI (similar to [Click](https://click.palletsprojects.com/en/8.1.x/)) which removes the need for separating CLI functions from actual code.  The logic behind the new CLI is quite verbose so will hopefully be easy to follow, but please let me know if things get confusing.

The logic behind parser help pages in particular are harder to parse (irony acknowledged!), but the associated test cases are sufficient to show how they fit together.  I encourage you to try out the CLI help pages yourself to make sure.

I very much recommend that we **do not** squash these commits. 