### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14.0-beta.2"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14.0-rc.3"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-beta.2"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14.0-beta.2"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![version](https://img.shields.io/badge/version-0.8.0-informational)
 ![pre-release](https://img.shields.io/badge/pre--release-beta-red)
-![python](https://img.shields.io/badge/python-%3E%3D3.9-informational)
+![python](https://img.shields.io/badge/python-%3E%3D10-informational)
 ![coverage](https://img.shields.io/badge/coverage-96%25-brightgreen)
 ![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=orange)
 

--- a/concoursetools/additional.py
+++ b/concoursetools/additional.py
@@ -44,7 +44,7 @@ class DatetimeVersion(TypedVersion):
     execution_date: datetime
 
     @classmethod
-    def now(cls) -> "DatetimeVersion":
+    def now(cls) -> DatetimeVersion:
         """Return the version corresponding to now."""
         return cls(datetime.now())
 
@@ -236,7 +236,7 @@ class MultiVersion(Version, Generic[SortableVersionT]):
         }
 
     @classmethod
-    def from_flat_dict(cls: "type[MultiVersion[SortableVersionT]]", version_dict: VersionConfig) -> "MultiVersion[SortableVersionT]":
+    def from_flat_dict(cls: type[MultiVersion[SortableVersionT]], version_dict: VersionConfig) -> MultiVersion[SortableVersionT]:
         """
         Load an instance from a dictionary representing the version.
 
@@ -382,7 +382,7 @@ class SelfOrganisingConcourseResource(ConcourseResource[SortableVersionT]):
 
 class _PseudoConcourseResource(ConcourseResource[VersionT]):
 
-    def __new__(cls) -> "_PseudoConcourseResource[VersionT]":
+    def __new__(cls) -> _PseudoConcourseResource[VersionT]:
         raise TypeError(f"Cannot instantiate a {cls.__name__} type")
 
 
@@ -425,7 +425,7 @@ def combine_resource_types(resources: dict[str, type[ConcourseResource[VersionT]
         A special Resource class which delegates to multiple other resource classes.
         """
         @classmethod
-        def _from_resource_config(cls, resource_config: ResourceConfig) -> "ConcourseResource[VersionT]":
+        def _from_resource_config(cls, resource_config: ResourceConfig) -> ConcourseResource[VersionT]:
             try:
                 resource_key = resource_config.pop(param_key)
             except KeyError as error:

--- a/concoursetools/cli/docstring.py
+++ b/concoursetools/cli/docstring.py
@@ -32,7 +32,7 @@ class Docstring:
     parameters: dict[str, str]
 
     @classmethod
-    def from_object(cls, obj: object) -> "Docstring":
+    def from_object(cls, obj: object) -> Docstring:
         """
         Parse an object with a docstring.
 
@@ -42,7 +42,7 @@ class Docstring:
         return cls.from_string(raw_docstring)
 
     @classmethod
-    def from_string(cls, raw_docstring: str) -> "Docstring":
+    def from_string(cls, raw_docstring: str) -> Docstring:
         """
         Parse a docstring.
 
@@ -63,7 +63,7 @@ class Docstring:
         return cls(first_line, description.strip(), parameters)
 
 
-def _pair_up(data: list[str]) -> Generator[tuple[str, str], None, None]:
+def _pair_up(data: list[str]) -> Generator[tuple[str, str]]:
     """
     Pair up a list of items.
 

--- a/concoursetools/cli/parser.py
+++ b/concoursetools/cli/parser.py
@@ -10,20 +10,14 @@ from collections.abc import Callable, Generator
 from dataclasses import dataclass
 import inspect
 import shutil
-import sys
 import textwrap
+from types import UnionType
 from typing import Any, Generic, TypeVar
 
 from concoursetools import __version__
 from concoursetools.cli.docstring import Docstring
 
-_CURRENT_PYTHON_VERSION = (sys.version_info.major, sys.version_info.minor)
-
-if _CURRENT_PYTHON_VERSION >= (3, 10):
-    from types import UnionType
-    _ANNOTATIONS_TO_TYPES: dict[type[Any] | UnionType | str, type] = {}
-else:
-    _ANNOTATIONS_TO_TYPES: dict[type[Any] | Any | str, type] = {}  # type: ignore[no-redef]
+_ANNOTATIONS_TO_TYPES: dict[type[Any] | UnionType | str, type] = {}
 
 CLIFunction = Callable[..., None]
 CLIFunctionT = TypeVar("CLIFunctionT", bound=CLIFunction)
@@ -37,8 +31,7 @@ for type_ in _AVAILABLE_TYPES:
         type_.__name__: type_,
         f"{type_.__name__} | None": type_,
     })
-    if _CURRENT_PYTHON_VERSION >= (3, 10):
-        _ANNOTATIONS_TO_TYPES[type_ | None] = type_
+    _ANNOTATIONS_TO_TYPES[type_ | None] = type_
 
 
 class _CLIParser(ABC):

--- a/concoursetools/cli/parser.py
+++ b/concoursetools/cli/parser.py
@@ -377,7 +377,7 @@ class Parameter(ABC, Generic[T]):
         ...
 
     @classmethod
-    def yield_from_function(cls, func: CLIFunction, allow_short: set[str]) -> Generator[Parameter[Any], None, None]:
+    def yield_from_function(cls, func: CLIFunction, allow_short: set[str]) -> Generator[Parameter[Any]]:
         """
         Yield parameters from a function.
 

--- a/concoursetools/colour.py
+++ b/concoursetools/colour.py
@@ -77,7 +77,7 @@ def colour_print(*values: object, colour: str = MISSING_COLOUR, bold: bool = Fal
 
 
 @contextmanager
-def print_in_colour(colour: str, bold: bool = False, underline: bool = False) -> Generator[None, None, None]:
+def print_in_colour(colour: str, bold: bool = False, underline: bool = False) -> Generator[None]:
     """
     Print anything in colour within a :ref:`context manager <context-managers>`.
 

--- a/concoursetools/importing.py
+++ b/concoursetools/importing.py
@@ -127,7 +127,7 @@ def import_py_file(import_path: str, file_path: Path) -> ModuleType:
 
 
 @contextmanager
-def edit_sys_path(prepend: Sequence[Path] = (), append: Sequence[Path] = ()) -> Generator[None, None, None]:
+def edit_sys_path(prepend: Sequence[Path] = (), append: Sequence[Path] = ()) -> Generator[None]:
     """
     Temporarily add to :data:`sys.path` within a context manager.
 

--- a/concoursetools/metadata.py
+++ b/concoursetools/metadata.py
@@ -217,7 +217,7 @@ class BuildMetadata:  # pylint: disable=invalid-name
         return template.safe_substitute(possible_values) if ignore_missing else template.substitute(possible_values)
 
     @classmethod
-    def from_env(cls) -> "BuildMetadata":
+    def from_env(cls) -> BuildMetadata:
         """Return an instance populated from the environment."""
         return cls(
             BUILD_ID=os.environ["BUILD_ID"],

--- a/concoursetools/mocking.py
+++ b/concoursetools/mocking.py
@@ -156,7 +156,7 @@ class TemporaryDirectoryState:
             raise RuntimeError("Final state is not set whilst temporary directory is still open.")
         return self._final_state
 
-    def __enter__(self) -> "TemporaryDirectoryState":
+    def __enter__(self) -> TemporaryDirectoryState:
         self._temp_dir = TemporaryDirectory(**self.temporary_directory_kwargs)
         self._set_folder_from_dict(self.path, self.starting_state, encoding=self.encoding)
         return self
@@ -278,7 +278,7 @@ class StringIOWrapper:
         self.inner_io = StringIO()
 
     @contextmanager
-    def capture_stdout_and_stderr(self) -> ContextManager["StringIOWrapper"]:
+    def capture_stdout_and_stderr(self) -> ContextManager[StringIOWrapper]:
         """
         Capture both :data:`~sys.stdout` and :data:`~sys.stderr`.
 
@@ -289,7 +289,7 @@ class StringIOWrapper:
                 yield self
 
     @contextmanager
-    def capture_stderr(self) -> ContextManager["StringIOWrapper"]:
+    def capture_stderr(self) -> ContextManager[StringIOWrapper]:
         """
         Capture :data:`~sys.stderr`.
 

--- a/concoursetools/mocking.py
+++ b/concoursetools/mocking.py
@@ -13,13 +13,11 @@ from pathlib import Path
 import sys
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import Any, TypeVar
+from typing import Any
 from unittest import mock
 
 from concoursetools import BuildMetadata
 
-T = TypeVar("T")
-ContextManager = Generator[T, None, None]
 FolderDict = dict[str, Any]
 
 
@@ -278,7 +276,7 @@ class StringIOWrapper:
         self.inner_io = StringIO()
 
     @contextmanager
-    def capture_stdout_and_stderr(self) -> ContextManager[StringIOWrapper]:
+    def capture_stdout_and_stderr(self) -> Generator[StringIOWrapper]:
         """
         Capture both :data:`~sys.stdout` and :data:`~sys.stderr`.
 
@@ -289,7 +287,7 @@ class StringIOWrapper:
                 yield self
 
     @contextmanager
-    def capture_stderr(self) -> ContextManager[StringIOWrapper]:
+    def capture_stderr(self) -> Generator[StringIOWrapper]:
         """
         Capture :data:`~sys.stderr`.
 
@@ -300,7 +298,7 @@ class StringIOWrapper:
 
 
 @contextmanager
-def mock_environ(new_environ: dict[str, str]) -> ContextManager[None]:
+def mock_environ(new_environ: dict[str, str]) -> Generator[None]:
     """
     Mock :data:`os.environ` in a context manager.
 
@@ -317,7 +315,7 @@ def mock_environ(new_environ: dict[str, str]) -> ContextManager[None]:
 
 
 @contextmanager
-def mock_stdin(stdin: str) -> ContextManager[None]:
+def mock_stdin(stdin: str) -> Generator[None]:
     """
     Mock :data:`~sys.stdin` in a context manager.
 
@@ -338,7 +336,7 @@ def mock_stdin(stdin: str) -> ContextManager[None]:
 
 
 @contextmanager
-def mock_argv(*args: str) -> ContextManager[None]:
+def mock_argv(*args: str) -> Generator[None]:
     """
     Mock :data:`sys.argv` in a context manager.
 

--- a/concoursetools/resource.py
+++ b/concoursetools/resource.py
@@ -275,7 +275,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         _output(output)
 
     @classmethod
-    def _parse_check_input(cls) -> tuple["ConcourseResource[VersionT]", VersionT | None]:
+    def _parse_check_input(cls) -> tuple[ConcourseResource[VersionT], VersionT | None]:
         """Parse input from the command line."""
         check_payload = sys.stdin.read()
 
@@ -291,7 +291,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         return resource, previous_version
 
     @classmethod
-    def _parse_in_input(cls) -> tuple["ConcourseResource[VersionT]", VersionT, Path, Params]:
+    def _parse_in_input(cls) -> tuple[ConcourseResource[VersionT], VersionT, Path, Params]:
         """Parse input from the command line."""
         in_payload = sys.stdin.read()
 
@@ -309,7 +309,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         return resource, version, destination_dir, params
 
     @classmethod
-    def _parse_out_input(cls) -> tuple["ConcourseResource[VersionT]", Path, Params]:
+    def _parse_out_input(cls) -> tuple[ConcourseResource[VersionT], Path, Params]:
         """Parse input from the command line."""
         out_payload = sys.stdin.read()
 
@@ -326,7 +326,7 @@ class ConcourseResource(ABC, Generic[VersionT]):
         return resource, sources_dir, params
 
     @classmethod
-    def _from_resource_config(cls, resource_config: ResourceConfig) -> "ConcourseResource[VersionT]":
+    def _from_resource_config(cls, resource_config: ResourceConfig) -> ConcourseResource[VersionT]:
         return cls(**resource_config)
 
 

--- a/concoursetools/testing.py
+++ b/concoursetools/testing.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import secrets
 import subprocess
 from tempfile import TemporaryDirectory
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic
 
 from concoursetools import BuildMetadata, ConcourseResource, Version
 from concoursetools.dockertools import MethodName, ScriptName, create_script_file
@@ -27,8 +27,6 @@ from concoursetools.mocking import StringIOWrapper, TemporaryDirectoryState, cre
 from concoursetools.parsing import format_check_input, format_in_input, format_out_input, parse_metadata
 from concoursetools.typing import Metadata, MetadataPair, Params, ResourceConfig, VersionConfig, VersionT
 
-T = TypeVar("T")
-ContextManager = Generator[T, None, None]
 FolderDict = dict[str, Any]
 
 
@@ -90,7 +88,7 @@ class TestResourceWrapper(ABC, Generic[VersionT]):
         """
 
     @contextmanager
-    def capture_debugging(self) -> ContextManager[StringIOWrapper]:
+    def capture_debugging(self) -> Generator[StringIOWrapper]:
         """
         Redirect the resource debugging output within a context manager into a variable.
 
@@ -105,7 +103,7 @@ class TestResourceWrapper(ABC, Generic[VersionT]):
         yield self._debugging_output
 
     @contextmanager
-    def capture_directory_state(self, starting_state: FolderDict | None = None) -> ContextManager[TemporaryDirectoryState]:
+    def capture_directory_state(self, starting_state: FolderDict | None = None) -> Generator[TemporaryDirectoryState]:
         """
         Open a context manager to expose the internal state of the resource.
 
@@ -127,7 +125,7 @@ class TestResourceWrapper(ABC, Generic[VersionT]):
                 self._directory_state.starting_state = old_start_state
 
     @contextmanager
-    def _forbid_methods(self, *methods: Callable[..., object]) -> ContextManager[None]:
+    def _forbid_methods(self, *methods: Callable[..., object]) -> Generator[None]:
         try:
             for method in methods:
                 def new_method(*args: object, **kwargs: object) -> object:
@@ -638,7 +636,7 @@ class FileConversionTestResourceWrapper(FileTestResourceWrapper, Generic[Version
         return new_version, metadata
 
     @contextmanager
-    def _temporarily_create_script_file(self, script_name: ScriptName, method_name: MethodName) -> ContextManager[None]:
+    def _temporarily_create_script_file(self, script_name: ScriptName, method_name: MethodName) -> Generator[None]:
         attribute_name = f"{script_name}_script"
         try:
             with TemporaryDirectory() as temp_dir:

--- a/concoursetools/testing.py
+++ b/concoursetools/testing.py
@@ -105,7 +105,7 @@ class TestResourceWrapper(ABC, Generic[VersionT]):
         yield self._debugging_output
 
     @contextmanager
-    def capture_directory_state(self, starting_state: FolderDict | None = None) -> ContextManager["TemporaryDirectoryState"]:
+    def capture_directory_state(self, starting_state: FolderDict | None = None) -> ContextManager[TemporaryDirectoryState]:
         """
         Open a context manager to expose the internal state of the resource.
 
@@ -514,9 +514,9 @@ class FileTestResourceWrapper(TestResourceWrapper[Version]):
         return new_version_config, metadata_pairs
 
     @classmethod
-    def from_assets_dir(cls: type["FileTestResourceWrapper"], inner_resource_config: ResourceConfig, assets_dir: Path,
+    def from_assets_dir(cls: type[FileTestResourceWrapper], inner_resource_config: ResourceConfig, assets_dir: Path,
                         directory_dict: FolderDict | None = None, one_off_build: bool = False,
-                        instance_vars: dict[str, str] | None = None, **env_vars: str) -> "FileTestResourceWrapper":
+                        instance_vars: dict[str, str] | None = None, **env_vars: str) -> FileTestResourceWrapper:
         """
         Create an instance from a single folder of asset files.
 
@@ -958,8 +958,7 @@ def run_command(command: str, additional_args: list[str] | None = None, env: dic
             cwd=cwd,
             check=True,
             input=stdin.encode() if stdin is not None else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
         )
     except subprocess.CalledProcessError as error:
         error_message: bytes = error.stderr

--- a/concoursetools/version.py
+++ b/concoursetools/version.py
@@ -262,15 +262,7 @@ class TypedVersion(Version):
     _un_flatten_functions: ClassVar[MutableMapping[type[Any], Callable[[type[Any], str], Any]]] = _TypeKeyDict()
 
     def __init_subclass__(cls) -> None:
-        try:
-            annotations = inspect.get_annotations(cls)
-        except AttributeError:
-            # Function isn't available in Python 3.9, so use the old code until EOL
-            try:
-                annotations = vars(cls)["__annotations__"]  # avoid MRO lookup
-            except KeyError:
-                annotations = {}
-
+        annotations = inspect.get_annotations(cls)
         if len(annotations) == 0:
             raise TypeError("Can't instantiate  dataclass TypedVersion without any fields")
 

--- a/docs/source/changelog/development.rst
+++ b/docs/source/changelog/development.rst
@@ -4,3 +4,4 @@ Development
 
 * Added Python 3.14 support.
 * Documentation is now built with Python 3.13.
+* Dropped support for Python 3.9.

--- a/examples/build_status.py
+++ b/examples/build_status.py
@@ -41,7 +41,7 @@ class BitbucketOAuth(AuthBase):
         return request
 
     @classmethod
-    def from_client_credentials(cls, client_id: str, client_secret: str) -> "BitbucketOAuth":
+    def from_client_credentials(cls, client_id: str, client_secret: str) -> BitbucketOAuth:
         token_auth = HTTPBasicAuth(client_id, client_secret)
 
         url = "https://bitbucket.org/site/oauth2/access_token"

--- a/examples/pipeline.py
+++ b/examples/pipeline.py
@@ -113,7 +113,7 @@ class PipelineResource(ConcourseResource[ExecutionVersion]):
         new_version = ExecutionVersion(execution_arn)
         return new_version, metadata
 
-    def _yield_potential_execution_versions(self) -> Generator[ExecutionVersion, None, None]:
+    def _yield_potential_execution_versions(self) -> Generator[ExecutionVersion]:
         kwargs = {
             "PipelineName": self.pipeline_name,
             "SortOrder": "Descending",

--- a/examples/xkcd.py
+++ b/examples/xkcd.py
@@ -80,14 +80,14 @@ class XKCDResource(SelfOrganisingConcourseResource[ComicVersion]):
         raise NotImplementedError
 
 
-def yield_comic_ids(xml_data: str) -> Generator[int, None, None]:
+def yield_comic_ids(xml_data: str) -> Generator[int]:
     for comic_url in yield_comic_links(xml_data):
         parsed_url = urllib.parse.urlparse(comic_url)
         comic_id = parsed_url.path.strip("/")
         yield int(comic_id)
 
 
-def yield_comic_links(xml_data: str) -> Generator[str, None, None]:
+def yield_comic_links(xml_data: str) -> Generator[str]:
     root = ET.fromstring(xml_data)
     for entry in root:
         if entry.tag.endswith("entry"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "concoursetools"
 dynamic = ["version"]
 description = "Easily create Concourse resource types in Python."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = [
     "concourse",
     "ci",
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectDescription="Static analysis for the Concourse Tools Python library
 sonar.sources=concoursetools
 sonar.tests=tests
 
-sonar.python.version=3.9,3.10,3.11,3.12,3.13,3.14
+sonar.python.version=3.10,3.11,3.12,3.13,3.14
 
 sonar.coverage.exclusions=docs/**/*,tests/**/*,coverage.xml,concoursetools/colour.py,concoursetools/typing.py,**/__init__.py,**/__main__.py
 sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -52,7 +52,7 @@ class FileVersion(Version):
         return {"files": json.dumps(list(self.files))}
 
     @classmethod
-    def from_flat_dict(cls, version_dict: VersionConfig) -> "FileVersion":
+    def from_flat_dict(cls, version_dict: VersionConfig) -> FileVersion:
         return cls(set(json.loads(version_dict["files"])))
 
 

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -9,7 +9,7 @@ import unittest
 import unittest.mock
 
 from concoursetools import __version__
-from concoursetools.cli.parser import _ANNOTATIONS_TO_TYPES, _CURRENT_PYTHON_VERSION, CLI, Docstring
+from concoursetools.cli.parser import _ANNOTATIONS_TO_TYPES, CLI, Docstring
 
 
 class ParsingTests(unittest.TestCase):
@@ -256,8 +256,6 @@ class AnnotationTests(unittest.TestCase):
         self.assertEqual(_ANNOTATIONS_TO_TYPES[float], float)
 
     def test_optional_types(self) -> None:
-        if _CURRENT_PYTHON_VERSION < (3, 10):
-            self.skipTest("Union types with '|' only valid for Python >= 3.10.")
         self.assertEqual(_ANNOTATIONS_TO_TYPES[str | None], str)
         self.assertEqual(_ANNOTATIONS_TO_TYPES[bool | None], bool)
         self.assertEqual(_ANNOTATIONS_TO_TYPES[int | None], int)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -58,11 +58,11 @@ class MockedTextResponse:
     def text(self) -> str:
         return self._data
 
-    def get(self, *args: object, **kwargs: object) -> "MockedTextResponse":
+    def get(self, *args: object, **kwargs: object) -> MockedTextResponse:
         return self
 
     @classmethod
-    def from_file(cls, file_path: str, status_code: int = 200) -> "MockedTextResponse":
+    def from_file(cls, file_path: str, status_code: int = 200) -> MockedTextResponse:
         with open(file_path) as rf:
             data = rf.read()
         return cls(data, status_code)
@@ -76,7 +76,7 @@ class MockedJSONResponse:
         self._json_data = json_data
         self._status_code = status_code
 
-    def get(self, *args: object, **kwargs: object) -> "MockedJSONResponse":
+    def get(self, *args: object, **kwargs: object) -> MockedJSONResponse:
         return self
 
     def json(self) -> Any:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -301,7 +301,7 @@ class FileWrapperTests(TestCase):
         """Code to run before each test."""
         self.temp_dir = TemporaryDirectory()
         cli_commands.assets(self.temp_dir.name, resource_file="tests/resource.py",
-                            class_name=TestResource.__name__, executable="/usr/bin/env python3")
+                            class_name=TestResource.__name__, executable=sys.executable)
 
         config = {
             "uri": "git://some-uri",
@@ -409,7 +409,7 @@ class FileConversionWrapperTests(TestCase):
             "branch": "develop",
             "private_key": "...",
         }
-        self.wrapper = FileConversionTestResourceWrapper(TestResource, config, executable="/usr/bin/env python3")
+        self.wrapper = FileConversionTestResourceWrapper(TestResource, config, executable=sys.executable)
 
     def test_check_step_with_version_no_debugging(self) -> None:
         version = TestVersion("61cbef")


### PR DESCRIPTION
This MR officially drops support for 3.9, making the following changes:

* Remove all references to 3.9 in the metadata, and set the `requires-python` flag to `">=3.10"`.
* Remove 3.9 from the CI.
* Ran [`pyupgrade`](https://pypi.org/project/pyupgrade/) across the codebase.
* Removed two blocks of code with specific logic for Python 3.9.
* Also updated the Python 3.14 version in CI to the latest release candidate.