### PR TITLE
Added Python 3.15 support

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-rc.1"]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python ${{ matrix.python-version }}

--- a/docs/source/changelog/development.rst
+++ b/docs/source/changelog/development.rst
@@ -1,2 +1,4 @@
 Development
 ===========
+
+* Added Python 3.15 support

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Topic :: Software Development",
     "Typing :: Typed",
 ]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectDescription="Static analysis for the Concourse Tools Python library
 sonar.sources=concoursetools
 sonar.tests=tests
 
-sonar.python.version=3.10,3.11,3.12,3.13,3.14
+sonar.python.version=3.10,3.11,3.12,3.13,3.14,3.15
 
 sonar.coverage.exclusions=docs/**/*,tests/**/*,coverage.xml,concoursetools/colour.py,concoursetools/typing.py,**/__init__.py,**/__main__.py
 sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
This PR adds the `Programming Language :: Python :: 3.15` classifier and updates the CI to run the tests on the Python 3.15 release candidate.