### PR TITLE
Fixed typing in  'import_classes_from_module' function

### DIFF
--- a/concoursetools/importing.py
+++ b/concoursetools/importing.py
@@ -57,17 +57,16 @@ def import_classes_from_module(file_path: Path, parent_class: type[T]) -> dict[s
     import_path = file_path_to_import_path(file_path)
     module = import_py_file(import_path, file_path)
 
-    possible_resource_classes = {}
+    possible_resource_classes: dict[str, type[T]] = {}
     for _, cls in inspect.getmembers(module, predicate=inspect.isclass):
-        try:
-            class_is_subclass_of_parent = issubclass(cls, parent_class)
-        except TypeError:
-            class_is_subclass_of_parent = False
+
+        if not issubclass(cls, parent_class):
+            continue
 
         class_is_defined_in_this_module = (cls.__module__ == import_path)
         class_is_not_private = (not cls.__name__.startswith("_"))
 
-        if class_is_subclass_of_parent and class_is_defined_in_this_module and class_is_not_private:
+        if class_is_defined_in_this_module and class_is_not_private:
             possible_resource_classes[cls.__name__] = cls
 
     return possible_resource_classes

--- a/concoursetools/importing.py
+++ b/concoursetools/importing.py
@@ -60,7 +60,11 @@ def import_classes_from_module(file_path: Path, parent_class: type[T]) -> dict[s
     possible_resource_classes: dict[str, type[T]] = {}
     for _, cls in inspect.getmembers(module, predicate=inspect.isclass):
 
-        if not issubclass(cls, parent_class):
+        try:
+            if not issubclass(cls, parent_class):
+                continue
+        except TypeError:
+            # This can fail in Python 3.10
             continue
 
         class_is_defined_in_this_module = (cls.__module__ == import_path)


### PR DESCRIPTION
This PR fixes a typing error that occurs in the `import_classes_from_module` function on newer versions of `mypy`:

```
concoursetools/importing.py:73: error: Incompatible return value type (got "dict[str, type[object]]", expected "dict[str, type[T]]")  [return-value]
```

For some reason, `issubclass` was not type narrowing. I've rewritten the code slightly to drop a conditional in favour of an earlier `continue` statement. This also avoids a _tiny_ bit of work for other classes.

~~In additional, I dropped a `try`/`except` block for a `TypeError` raised by `issubclass`. I assume this exists because `issubclass` will raise `TypeError` if not passed a class, but given we're running `inspect.isclass` as a predicate above, I assume the only issue we could have here would be due to some particularly heinous metaprogramming, so I think it's fine!~~

This has now been reverted, as it turns out the issue was due to Python 3.10.